### PR TITLE
fix: missing schema files in wheel packaging and CLI version metadata…

### DIFF
--- a/collider/entrypoint.py
+++ b/collider/entrypoint.py
@@ -21,10 +21,30 @@ from collider.log import Level, configure_logging, logger
 from collider.utils import core
 
 
+_DIST_NAME = 'collider-wraps'
+
+
 class _RawDescriptionArgumentDefaultsHelpFormatter(
     argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
 ):
     """Argument parser formatter that supports raw descriptions with defaults."""
+
+
+def _get_installed_version() -> str:
+    """Resolve the published distribution version, not the import package name."""
+    try:
+        return importlib.metadata.version(_DIST_NAME)
+    except PackageNotFoundError:
+        return '0.0.0'
+
+
+def _get_project_url() -> str:
+    """Read project metadata from the installed distribution when available."""
+    try:
+        metadata = importlib.metadata.metadata(_DIST_NAME)
+        return str(metadata.get('Project-URL')).split(', ')[1]  # ty:ignore[unresolved-attribute]
+    except (PackageNotFoundError, AttributeError, ValueError, IndexError):
+        return 'https://github.com/MaxandreOgeret/collider'
 
 
 def error_handler(e: Exception) -> None:
@@ -32,12 +52,7 @@ def error_handler(e: Exception) -> None:
     Handle unhandled exceptions with user-friendly error reporting and bug reporting instructions.
     :param e: Exception to report.
     """
-
-    try:
-        metadata = importlib.metadata.metadata(collider.__name__)
-        project_url = str(metadata.get('Project-URL')).split(', ')[1]  # ty:ignore[unresolved-attribute]
-    except (PackageNotFoundError, AttributeError, ValueError, IndexError):
-        project_url = 'https://github.com/MaxandreOgeret/collider'
+    project_url = _get_project_url()
     logger.critical(
         'Oi oi oi päkapikk! '
         'Collider encountered an unhandled error, this is probably a bug within collider.'
@@ -113,10 +128,7 @@ def main() -> int:
 
     # Create context.
     configure_logging(app_args.verbose)
-    try:
-        version = importlib.metadata.version(collider.__name__)
-    except PackageNotFoundError:
-        version = '0.0.0'
+    version = _get_installed_version()
 
     logger.info(f'{collider.__name__.capitalize()} {version} - {parser.description}')
     context = config.load(offline=app_args.offline)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ collider = "collider.entrypoint:entrypoint"
 include = ["collider*"]
 exclude = ["subprojects*"]
 
+[tool.setuptools.package-data]
+collider = ["file_model/schema/*.json"]
+
 # ------- Pytest -----------------------------------------------------------------
 [tool.pytest.ini_options]
 testpaths = ["test"]

--- a/test/entrypoint/test_entrypoint.py
+++ b/test/entrypoint/test_entrypoint.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from collider.entrypoint import entrypoint, error_handler
+from collider.entrypoint import _get_installed_version, entrypoint, error_handler
 from collider.log import Level, logger
 
 
@@ -136,6 +136,14 @@ def test_error_handler_verbose(caplog) -> None:
         assert 'Verbose Error' in caplog.text
     finally:
         logger.setLevel(original_level)
+
+
+def test_get_installed_version_uses_distribution_name() -> None:
+    """Version lookup should use the published distribution name."""
+    with patch('importlib.metadata.version', return_value='1.0.0') as mock_version:
+        assert _get_installed_version() == '1.0.0'
+
+    mock_version.assert_called_once_with('collider-wraps')
 
 
 def test_entrypoint_unhandled_exception_exits_nonzero() -> None:

--- a/test/file_model/test_schema.py
+++ b/test/file_model/test_schema.py
@@ -2,11 +2,58 @@
 # Copyright (c) 2026 MOG Robotics OÜ.
 
 import json
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
 
 from pathlib import Path
 
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
+    import tomli as tomllib
+
 from collider.file_model.configfile import ConfigFile
 from collider.repository import RepoImplRegistry
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _find_wheel_builder() -> str | None:
+    """Pick a Python executable that can invoke pip."""
+    python_location = os.environ.get('pythonLocation')
+    candidates = [
+        sys.executable,
+        getattr(sys, '_base_executable', None),
+        str(Path(sys.base_prefix) / 'bin' / 'python3'),
+        str(Path(sys.base_prefix) / 'bin' / 'python'),
+        str(Path(python_location) / 'bin' / 'python3') if python_location else None,
+        str(Path(python_location) / 'bin' / 'python') if python_location else None,
+        shutil.which('python3'),
+        shutil.which('python'),
+    ]
+    seen: set[str] = set()
+
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+
+        result = subprocess.run(
+            [candidate, '-c', 'import pip'],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=_PROJECT_ROOT,
+        )
+        if result.returncode == 0:
+            return candidate
+
+    return None
 
 
 def test_configfile_schema_accepts_wrap(tmp_path: Path):
@@ -41,3 +88,39 @@ def test_configfile_schema_accepts_collider(tmp_path: Path):
     )
     cfg = ConfigFile.from_path(path)
     assert cfg.repositories[0].type == RepoImplRegistry.collider
+
+
+def test_wheel_includes_schema_files(tmp_path: Path) -> None:
+    """Published wheels must ship the JSON schemas used at runtime."""
+    pyproject = tomllib.loads((_PROJECT_ROOT / 'pyproject.toml').read_text(encoding='utf-8'))
+    package_data = pyproject['tool']['setuptools']['package-data']['collider']
+    assert 'file_model/schema/*.json' in package_data
+
+    builder = _find_wheel_builder()
+    assert builder is not None, 'No Python interpreter with pip available.'
+
+    result = subprocess.run(
+        [
+            builder,
+            '-m',
+            'pip',
+            'wheel',
+            '--no-deps',
+            '.',
+            '-w',
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=_PROJECT_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+
+    wheel_path = next(tmp_path.glob('collider_wraps-*.whl'))
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+
+    assert 'collider/file_model/schema/configfile.schema.json' in names
+    assert 'collider/file_model/schema/colliderfile.schema.json' in names
+    assert 'collider/file_model/schema/lockfile.schema.json' in names


### PR DESCRIPTION

## Summary

Fix pip-installed packaging by including JSON schema files in the built wheel, and fix CLI version lookup to use the published distribution metadata instead of falling back to 0.0.0. Add regression tests covering wheel contents, version lookup, and Python 3.10/CI-compatible wheel validation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Tests pass locally (e.g. `uv run pytest`)
- [x] Code follows project style (e.g. `uv run ruff check .`)
