### PR TITLE
fix(ci): make docs deploy fail loudly instead of silently

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,6 +25,9 @@ jobs:
       DOCS_DEPLOY_WEB_GROUP: ${{ vars.DOCS_DEPLOY_WEB_GROUP || 'caddy' }}
       DOCS_DEPLOY_KNOWN_HOSTS: ${{ vars.DOCS_DEPLOY_KNOWN_HOSTS }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Validate deploy configuration
         run: |
           test -n "$DOCS_DEPLOY_HOST"
@@ -46,6 +49,7 @@ jobs:
 
       - name: Deploy docs on server
         run: |
+          set -euo pipefail
           cat .ci/deploy-docs.sh | ssh -p "$DOCS_DEPLOY_PORT" "$DOCS_DEPLOY_USER@$DOCS_DEPLOY_HOST" \
             "sudo -n -u collider env \
              REPO_DIR='$DOCS_DEPLOY_REPO_DIR' \
@@ -56,5 +60,6 @@ jobs:
 
       - name: Restart collider repo service
         run: |
+          set -eu
           ssh -p "$DOCS_DEPLOY_PORT" "$DOCS_DEPLOY_USER@$DOCS_DEPLOY_HOST" \
             "sudo -n systemctl restart collider_repo.service"


### PR DESCRIPTION
- Add checkout step so .ci/deploy-docs.sh exists on the runner
- Use set -euo pipefail in deploy step so cat/ssh/remote script failures fail the job
- Use set -eu in restart step

## Summary

Brief description of the change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] Tests pass locally (e.g. `uv run pytest`)
- [ ] Code follows project style (e.g. `uv run ruff check .`)
