### PR TITLE
feat: add README badges and Codecov coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v5
-      - name: Create venv
-        run: uv venv
-      - name: Install test tools
-        run: |
-          uv pip install pytest pytest-cov
+      - name: Install dependencies
+        run: uv sync --group dev
       - name: Pytest
-        run: uv run pytest
+        run: uv run pytest --cov=collider --cov-branch --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 <img src="https://collider.ee/assets/logo.svg" width="300">
 </p>
 
+<p align="center">
+  <a href="https://github.com/MaxandreOgeret/collider/actions/workflows/tests.yml"><img src="https://github.com/MaxandreOgeret/collider/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
+  <a href="https://github.com/MaxandreOgeret/collider/actions/workflows/lint.yml"><img src="https://github.com/MaxandreOgeret/collider/actions/workflows/lint.yml/badge.svg" alt="Lint"></a>
+  <a href="https://pypi.org/project/collider-wraps/"><img src="https://img.shields.io/pypi/v/collider-wraps?label=PyPI" alt="PyPI"></a>
+  <a href="https://github.com/MaxandreOgeret/collider/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
+  <a href="https://codecov.io/gh/MaxandreOgeret/collider"><img src="https://codecov.io/gh/MaxandreOgeret/collider/graph/badge.svg" alt="codecov"></a>
+</p>
+
 A package and dependency manager for Meson projects, centered on Meson's wrap system.
 
 ## Status


### PR DESCRIPTION
- Add badges: Tests, Lint, PyPI, Python, License, Codecov
- Run tests with uv sync --group dev and coverage flags for Codecov
- Upload coverage via codecov-action@v5 with CODECOV_TOKEN

## Summary

Brief description of the change.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] Tests pass locally (e.g. `uv run pytest`)
- [ ] Code follows project style (e.g. `uv run ruff check .`)
