### PR TITLE
ci: publish pytest results as JUnit XML in Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ jobs:
   pytest:
     name: pytest (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write   # required for publish-unit-test-result-action to create check runs
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +27,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
       - name: Pytest
-        run: uv run pytest --cov=collider --cov-branch --cov-report=xml
+        run: uv run pytest --cov=collider --cov-branch --cov-report=xml --junitxml=test-results/junit.xml
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: test-results/**/*.xml
+          comment_mode: off   # avoid needing pull-requests: write; check run + job summary only
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
- Add --junitxml=test-results/junit.xml to pytest
- Use EnricoMi/publish-unit-test-result-action for test summary and annotations

## Summary

Brief description of the change.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] Tests pass locally (e.g. `uv run pytest`)
- [ ] Code follows project style (e.g. `uv run ruff check .`)
