### PR TITLE
Fix/cache key and publish excludes

### DIFF
--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -3,6 +3,7 @@
 
 """WrapDB-compatible remote repository."""
 
+import hashlib
 import json
 import time
 import urllib.parse
@@ -34,6 +35,20 @@ def _wrap_releases_to_packages(
 ) -> dict[RepoKey, RepoPackageEntry]:
     """Convert WrapDB releases to an in-memory package index."""
     return packages_from_releases(wrap_releases)
+
+
+def _releases_cache_path(cache_path: Path, url: urllib.parse.ParseResult) -> Path:
+    """
+    Derive a collision-free cache file path for a repository's releases.json.
+
+    Keying on the full URL (not just the host) prevents repositories that share
+    a host but differ by path from clobbering or stale-serving each other.
+    :param cache_path: Cache root directory.
+    :param url: Effective repository URL the releases were fetched from.
+    :return: Path to the cached releases.json for this repository.
+    """
+    digest = hashlib.sha256(url.geturl().encode('utf-8')).hexdigest()[:16]
+    return Path(cache_path) / 'wrapdb' / f'{url.netloc}-{digest}' / _RELEASES_FILENAME
 
 
 def _ensure_v2_url(url: urllib.parse.ParseResult) -> urllib.parse.ParseResult:
@@ -81,7 +96,7 @@ class Wrap(RepositoryInterface):
         releases_url = urllib.parse.urljoin(effective_url.geturl(), _RELEASES_FILENAME)
         cache_file: Optional[Path] = None
         if cache_path is not None:
-            cache_file = Path(cache_path) / 'wrapdb' / url.netloc / _RELEASES_FILENAME
+            cache_file = _releases_cache_path(cache_path, effective_url)
 
         releases: dict[str, WrapDbReleasesEntry]
         if offline:

--- a/collider/subcommand/Publish.py
+++ b/collider/subcommand/Publish.py
@@ -202,7 +202,11 @@ class Publish(SubcommandInterface):
                 rel = Path(*rel.parts[1:])
             if not rel.parts:
                 return tarinfo
-            if rel.parts[0] in exclude_names:
+            # Match at any depth so nested VCS/cache directories are excluded too.
+            if any(part in exclude_names for part in rel.parts):
+                return None
+            # Drop Meson's downloaded archive cache; it bundles other packages' sources.
+            if rel.parts[:2] == ('subprojects', 'packagecache'):
                 return None
             if build_rel and tuple(rel.parts[: len(build_rel)]) == build_rel:
                 return None

--- a/test/repository/implementation/test_mesonwrapdb.py
+++ b/test/repository/implementation/test_mesonwrapdb.py
@@ -15,11 +15,18 @@ from collider.repository.entries import RepoPackageEntry
 from collider.repository.implementation.Wrap import (
     _RELEASES_TTL_SECONDS,
     Wrap,
+    _ensure_v2_url,
     _get_pkg_wrap_url,
+    _releases_cache_path,
     _wrap_releases_to_packages,
 )
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
+
+
+def _cache_file_for(cache_path, url_str: str):
+    """Resolve the releases.json cache path the way production code does."""
+    return _releases_cache_path(cache_path, _ensure_v2_url(urllib.parse.urlparse(url_str)))
 
 
 class _DummyResponse:
@@ -183,13 +190,36 @@ def test_wrap_get_package_parses_wrap(monkeypatch):
 
 def test_wrap_from_url_offline_uses_cache(tmp_path):
     cache_path = tmp_path / 'cache'
-    cache_file = cache_path / 'wrapdb' / 'wrapdb.mesonbuild.com' / 'releases.json'
+    cache_file = _cache_file_for(cache_path, 'https://wrapdb.mesonbuild.com/v2/')
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(json.dumps({'foo': {'versions': ['1.0.0']}}), encoding='utf-8')
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path, offline=True)
     repo_key = make_repo_key('foo', '1.0.0', PackageType.WRAP)
     assert repo_key in repo.packages
+
+
+def test_wrap_releases_cache_isolates_same_host_different_path(tmp_path):
+    """Repositories sharing a host but differing by path must not share a cache file."""
+    cache_path = tmp_path / 'cache'
+    url_a = 'https://packages.example.com/team-a/v2/'
+    url_b = 'https://packages.example.com/team-b/v2/'
+
+    cache_a = _cache_file_for(cache_path, url_a)
+    cache_b = _cache_file_for(cache_path, url_b)
+    assert cache_a != cache_b
+
+    cache_a.parent.mkdir(parents=True, exist_ok=True)
+    cache_b.parent.mkdir(parents=True, exist_ok=True)
+    cache_a.write_text(json.dumps({'a': {'versions': ['1.0.0']}}), encoding='utf-8')
+    cache_b.write_text(json.dumps({'b': {'versions': ['2.0.0']}}), encoding='utf-8')
+
+    repo_a = Wrap.from_url(url_a, cache_path=cache_path, offline=True)
+    repo_b = Wrap.from_url(url_b, cache_path=cache_path, offline=True)
+
+    assert make_repo_key('a', '1.0.0', PackageType.WRAP) in repo_a.packages
+    assert make_repo_key('b', '2.0.0', PackageType.WRAP) in repo_b.packages
+    assert make_repo_key('b', '2.0.0', PackageType.WRAP) not in repo_a.packages
 
 
 def test_wrap_from_url_offline_requires_cache(tmp_path):
@@ -200,7 +230,7 @@ def test_wrap_from_url_offline_requires_cache(tmp_path):
 def test_wrap_from_url_uses_ttl_cache_when_fresh(tmp_path, monkeypatch):
     """Cached releases.json within TTL skips the HTTP fetch entirely."""
     cache_path = tmp_path / 'cache'
-    cache_file = cache_path / 'wrapdb' / 'wrapdb.mesonbuild.com' / 'releases.json'
+    cache_file = _cache_file_for(cache_path, 'https://wrapdb.mesonbuild.com/v2/')
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(json.dumps({'foo': {'versions': ['1.0.0']}}), encoding='utf-8')
 
@@ -221,7 +251,7 @@ def test_wrap_from_url_uses_ttl_cache_when_fresh(tmp_path, monkeypatch):
 def test_wrap_from_url_fetches_when_ttl_expired(tmp_path, monkeypatch):
     """Stale cached releases.json (past TTL) triggers a fresh HTTP fetch."""
     cache_path = tmp_path / 'cache'
-    cache_file = cache_path / 'wrapdb' / 'wrapdb.mesonbuild.com' / 'releases.json'
+    cache_file = _cache_file_for(cache_path, 'https://wrapdb.mesonbuild.com/v2/')
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(json.dumps({'old': {'versions': ['0.1.0']}}), encoding='utf-8')
 
@@ -254,7 +284,7 @@ def test_wrap_from_url_fetches_when_no_cache(tmp_path, monkeypatch):
 def test_wrap_from_url_ttl_not_checked_in_offline_mode(tmp_path, monkeypatch):
     """Offline mode always uses cache regardless of age -- no TTL check."""
     cache_path = tmp_path / 'cache'
-    cache_file = cache_path / 'wrapdb' / 'wrapdb.mesonbuild.com' / 'releases.json'
+    cache_file = _cache_file_for(cache_path, 'https://wrapdb.mesonbuild.com/v2/')
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(json.dumps({'stale': {'versions': ['0.1.0']}}), encoding='utf-8')
 

--- a/test/subcommand/test_push.py
+++ b/test/subcommand/test_push.py
@@ -6,6 +6,7 @@ import configparser
 import json
 import os
 import socket
+import tarfile
 import threading
 import urllib.parse
 
@@ -164,6 +165,53 @@ def test_push_generates_wrap_and_archive(tmp_path: Path) -> None:
     assert wrap_section['source_hash'] == compute_file_hash(archive_path)
 
     assert wrap_parser['provide']['my-lib'] == 'my_lib_dep'
+
+
+def test_push_archive_excludes_artifacts_but_keeps_wraps(tmp_path: Path) -> None:
+    """Published source archive drops nested junk and packagecache, keeps subproject wraps."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+
+    config = MagicMock()
+    config.repositories = {'local': repo}
+    context = MagicMock(spec=Context)
+    context.config = config
+
+    source_dir = tmp_path / 'src'
+    (source_dir / 'src').mkdir(parents=True)
+    (source_dir / 'meson.build').write_text("project('demo', 'c')", encoding='utf-8')
+    (source_dir / 'src' / 'lib.c').write_text('int answer(void) { return 42; }', encoding='utf-8')
+
+    # Build artifacts and VCS noise that must never reach the published archive.
+    (source_dir / '.git').mkdir()
+    (source_dir / '.git' / 'config').write_text('[core]', encoding='utf-8')
+    (source_dir / 'src' / '__pycache__').mkdir()
+    (source_dir / 'src' / '__pycache__' / 'cached.pyc').write_text('x', encoding='utf-8')
+
+    # subprojects/: wraps are real source, packagecache is a build artifact.
+    (source_dir / 'subprojects').mkdir()
+    (source_dir / 'subprojects' / 'fmt.wrap').write_text('[wrap-file]', encoding='utf-8')
+    (source_dir / 'subprojects' / 'packagecache').mkdir()
+    (source_dir / 'subprojects' / 'packagecache' / 'fmt.tar.xz').write_bytes(b'archive')
+
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    cmd = Publish(_push_args(repository='local', builddir=builddir), context)
+    assert cmd.execute() == os.EX_OK
+
+    archive_path = repo_path / repo.ARCHIVE_DIR / 'demo_1.0.0' / 'demo-1.0.0.tar.xz'
+    with tarfile.open(archive_path) as tar:
+        members = {Path(name).relative_to('demo-1.0.0').as_posix() for name in tar.getnames()}
+
+    assert 'meson.build' in members
+    assert 'src/lib.c' in members
+    assert 'subprojects/fmt.wrap' in members
+    assert not any(m == '.git' or m.startswith('.git/') for m in members)
+    assert not any('__pycache__' in Path(m).parts for m in members)
+    assert not any(m.startswith('subprojects/packagecache') for m in members)
 
 
 def test_push_missing_repository(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Fixes two correctness issues found during a review of the install/publish/serve paths.

1. Per-repository releases cache was keyed on host only (Wrap.py). Two WrapDB-compatible repositories sharing a host but differing by path (e.g. https://pkgs.example.com/team-a/v2/ and .../team-b/v2/) both resolved to wrapdb/<netloc>/releases.json. Within the 300s TTL one repo served the other's index; outside it they clobbered each other. The cache file is now keyed on a SHA-256 of the full effective URL via a shared _releases_cache_path helper, so distinct repositories stay isolated.

2. Publish source archive excluded too little (Publish.py). The tar filter only matched exclude names against the top-level path segment, so nested VCS/build dirs (src/.../__pycache__, nested .git/.venv) were bundled into published archives, and subprojects/packagecache/ (Meson's downloaded archive cache, which embeds other packages' sources) leaked in. The filter now matches exclude names at any depth and drops subprojects/packagecache/, while deliberately keeping the project's own subprojects/*.wrap files (a consumer building the published package needs them).

Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] Tests pass locally (e.g. `uv run pytest`)
- [x] Code follows project style (e.g. `uv run ruff check .`)
