### PR TITLE
fix(meson): report missing or outdated Meson as a clean error, not a bug

### DIFF
--- a/collider/entrypoint.py
+++ b/collider/entrypoint.py
@@ -6,6 +6,7 @@
 import argparse
 import importlib
 import importlib.metadata
+import os
 import sys
 import traceback
 
@@ -19,6 +20,7 @@ from collider import config
 from collider.Context import Context
 from collider.log import Level, configure_logging, logger
 from collider.utils import core
+from collider.utils.meson.meson import MesonUnavailableError
 
 
 _DIST_NAME = 'collider-wraps'
@@ -144,7 +146,12 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    return args.func(args)
+    try:
+        return args.func(args)
+    except MesonUnavailableError:
+        # A missing or outdated Meson is a user environment problem, not a Collider bug,
+        # so report a clean exit code instead of routing it through error_handler.
+        return os.EX_UNAVAILABLE
 
 
 def entrypoint() -> None:

--- a/collider/utils/meson/meson.py
+++ b/collider/utils/meson/meson.py
@@ -22,18 +22,21 @@ DEFAULT_BUILD_DIR = Path('collider-build')
 SUBPROJECTS_DIR = Path('subprojects')
 
 
+class MesonUnavailableError(Exception):
+    """Raised when Meson is missing or too old: a user environment problem, not a Collider bug."""
+
+
 def validate() -> None:
     """
     Fail fast when Meson is missing or too old to avoid cryptic build errors.
-    :raises FileNotFoundError: When the meson executable is not found.
-    :raises RuntimeError: When the Meson version is below the minimum required.
+    :raises MesonUnavailableError: When the meson executable is missing or below the minimum version.
     """
 
     try:
         version = command.run(['meson', '--version'], capture=command.StdStream.STDOUT)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         logger.critical('Could not locate "meson" executable.')
-        raise
+        raise MesonUnavailableError('Could not locate "meson" executable.') from exc
 
     assert version is not None
     if Version(version) < _MINIMUM_VERSION:
@@ -43,7 +46,7 @@ def validate() -> None:
                 f'"{_MINIMUM_VERSION}", current version is "{version}".'
             )
         )
-        raise RuntimeError(msg)
+        raise MesonUnavailableError(msg)
 
     logger.info(
         f'Using meson version: "{version}".',

--- a/collider/utils/meson/meson.py
+++ b/collider/utils/meson/meson.py
@@ -17,7 +17,7 @@ from collider.log import logger
 from collider.utils import command
 
 
-_MINIMUM_VERSION = Version('1.8.1')
+_MINIMUM_VERSION = Version('1.8.5')
 DEFAULT_BUILD_DIR = Path('collider-build')
 SUBPROJECTS_DIR = Path('subprojects')
 

--- a/test/entrypoint/test_entrypoint.py
+++ b/test/entrypoint/test_entrypoint.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 MOG Robotics OÜ.
 
 import logging
+import os
 import subprocess
 import sys
 
@@ -12,6 +13,7 @@ import pytest
 
 from collider.entrypoint import _get_installed_version, entrypoint, error_handler
 from collider.log import Level, logger
+from collider.utils import meson
 
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -152,3 +154,22 @@ def test_entrypoint_unhandled_exception_exits_nonzero() -> None:
         with pytest.raises(SystemExit) as exc:
             entrypoint()
     assert exc.value.code == 1
+
+
+def test_entrypoint_meson_unavailable_returns_ex_unavailable(monkeypatch, caplog) -> None:
+    """Missing/outdated Meson exits with EX_UNAVAILABLE, not the internal-bug handler."""
+
+    def _raise_unavailable() -> None:
+        raise meson.MesonUnavailableError('Could not locate "meson" executable.')
+
+    monkeypatch.setattr(meson, 'validate', _raise_unavailable)
+    monkeypatch.setattr(sys, 'argv', ['collider', 'setup'])
+
+    with caplog.at_level(logging.CRITICAL, logger='collider'):
+        with pytest.raises(SystemExit) as exc:
+            entrypoint()
+
+    assert exc.value.code == os.EX_UNAVAILABLE
+    # The generic "this is a bug" handler must not fire for an environment problem.
+    assert 'Oi oi oi' not in caplog.text
+    assert 'probably a bug' not in caplog.text

--- a/test/subcommand/test_setup.py
+++ b/test/subcommand/test_setup.py
@@ -10,7 +10,22 @@ from pathlib import Path
 
 import pytest
 
+from collider.utils import meson
 from test.common.common import Subcommand, run_subcommand
+
+
+def test_setup_meson_unavailable_returns_ex_unavailable(tmp_path: Path, monkeypatch) -> None:
+    """`collider setup` returns EX_UNAVAILABLE when Meson is missing or too old."""
+
+    def _raise_unavailable() -> None:
+        raise meson.MesonUnavailableError('Could not locate "meson" executable.')
+
+    monkeypatch.setattr(meson, 'validate', _raise_unavailable)
+
+    assert (
+        run_subcommand(Subcommand.SETUP, ['--builddir', str(tmp_path / 'build')])
+        == os.EX_UNAVAILABLE
+    )
 
 
 def test_execute_success(meson_project: Path, tmp_path: Path) -> None:

--- a/test/utils/meson/test_meson.py
+++ b/test/utils/meson/test_meson.py
@@ -30,7 +30,7 @@ def test_validate_no_meson(monkeypatch, caplog):
 
     monkeypatch.setattr(meson.command, 'run', fake_run)
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(meson.MesonUnavailableError):
         meson.validate()
 
     assert 'Could not locate "meson" executable.' in caplog.text
@@ -44,7 +44,7 @@ def test_validate_version_too_low(monkeypatch, caplog):
 
     monkeypatch.setattr(meson.command, 'run', fake_run)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(meson.MesonUnavailableError):
         meson.validate()
 
     assert 'requires meson version' in caplog.text


### PR DESCRIPTION
## Summary

`meson.validate()` raised bare `FileNotFoundError` (Meson missing) or `RuntimeError` (Meson too old). `Setup.execute` calls it directly, and the exception propagated all the way to `entrypoint.error_handler`, which prints *"Collider encountered an unhandled error, this is probably a bug within collider"* and prompts the user to file a GitHub issue, directly contradicting the clear message `validate()` had just logged. The same misclassification surfaced during dependency resolution when Meson was too old (the resolver caught `FileNotFoundError` but not `RuntimeError`).

A missing or outdated build tool is a normal user environment condition, not an internal defect.

## Change

- Introduce `MesonUnavailableError`, raised by `meson.validate()`.
- Catch it centrally in `main()` and return `EX_UNAVAILABLE`.

This fixes every call site at once (setup and the resolver scan) without scattering try/except, and reserves `error_handler` for genuine bugs. Because `MesonUnavailableError` is a plain `Exception` (not a `FileNotFoundError`), it sails past the resolver's narrow `except` on its own, so `resolver.py` is untouched.

A second, separate commit aligns the enforced minimum Meson version (`1.8.1`) with the documented floor in README/`pyproject.toml` (`1.8.5`).

## Verification

- New `test_entrypoint_meson_unavailable_returns_ex_unavailable` drives the real `entrypoint()` wrapper and asserts `SystemExit.code == EX_UNAVAILABLE` and that the "this is a bug" message is absent. Both this and the `setup` command-path test were confirmed to fail on the pre-fix code and pass after.
- The **setup** path is verified by test; the **resolution** path returns a clean exit code by construction (the error either propagates to `main()`'s handler or is mapped to `EX_UNAVAILABLE` by the resolving commands' existing resolvelib `except`).
- Full suite: 540 passed, 89% coverage; `ruff format`/`ruff check`/`ty`/`pylint` (10.00/10) clean; `act` lint + tests jobs pass.