### PR TITLE
feat(publish): clear error when publishing a duplicate version

### DIFF
--- a/collider/repository/implementation/RepositoryInterface.py
+++ b/collider/repository/implementation/RepositoryInterface.py
@@ -19,6 +19,10 @@ from collider.utils.packaging.repo_key import make_repo_key, parse_repo_key
 from collider.utils.packaging.types import RepoKey
 
 
+class PackageAlreadyExistsError(ValueError):
+    """Raised when a package/version pair is already present in the repository."""
+
+
 class RepositoryInterface(ABC):
     """Shared repository API so callers are backend-agnostic."""
 
@@ -72,7 +76,7 @@ class RepositoryInterface(ABC):
         """Add a package and persist repository state in one step."""
         repo_key = self._make_repo_key(package.name, package.version)
         if repo_key in self.packages:
-            raise ValueError(f'Package {repo_key} already exists in repository.')
+            raise PackageAlreadyExistsError(f'Package {repo_key} already exists in repository.')
 
         entry = self._add_package_impl(
             package,

--- a/collider/subcommand/Publish.py
+++ b/collider/subcommand/Publish.py
@@ -24,6 +24,7 @@ from collider.log import logger
 from collider.Package import WrapPackage
 from collider.repository.implementation.Collider import Collider
 from collider.repository.implementation.Filesystem import Filesystem
+from collider.repository.implementation.RepositoryInterface import PackageAlreadyExistsError
 from collider.repository.implementation.Wrap import Wrap
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
@@ -160,6 +161,13 @@ class Publish(SubcommandInterface):
                     package, source_archive, self.patch_archive
                 )
                 self._push_remote_wrap_repo(repo, push_token, payload)
+        except PackageAlreadyExistsError:
+            logger.critical(
+                f'Version "{version}" of "{package_name}" already exists in repository '
+                f'"{self.repository_name}". Unpublish the existing version first, or bump '
+                'the project version.'
+            )
+            return os.EX_CANTCREAT
         except Exception as e:
             logger.critical(f'Failed to add package to repository: {e}')
             return os.EX_IOERR
@@ -335,6 +343,10 @@ class Publish(SubcommandInterface):
                     )
         except urllib.error.HTTPError as exc:
             response_body = exc.read().decode('utf-8', errors='replace')
+            if exc.code == 409:
+                raise PackageAlreadyExistsError(
+                    f'Remote push failed with HTTP 409: {response_body}'
+                ) from exc
             raise ValueError(f'Remote push failed with HTTP {exc.code}: {response_body}') from exc
         except urllib.error.URLError as exc:
             raise ValueError(f'Failed to reach remote push endpoint "{endpoint}": {exc}') from exc

--- a/collider/subcommand/Serve.py
+++ b/collider/subcommand/Serve.py
@@ -31,6 +31,7 @@ from collider.Context import Context
 from collider.log import logger
 from collider.Package import WrapPackage
 from collider.repository.implementation.Filesystem import Filesystem
+from collider.repository.implementation.RepositoryInterface import PackageAlreadyExistsError
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
 from collider.utils.packaging.PackageType import PackageType
@@ -215,12 +216,11 @@ class WrapApiHandler(SimpleHTTPRequestHandler):
                     source_archive=source_archive,
                     patch_archive=patch_archive,
                 )
+        except PackageAlreadyExistsError as exc:
+            self._send_json(409, {'error': str(exc)})
+            return
         except ValueError as exc:
-            message = str(exc)
-            if 'already exists in repository' in message:
-                self._send_json(409, {'error': message})
-                return
-            self._send_json(400, {'error': message})
+            self._send_json(400, {'error': str(exc)})
             return
         except RuntimeError as exc:
             self._send_json(413, {'error': str(exc)})

--- a/test/subcommand/test_push.py
+++ b/test/subcommand/test_push.py
@@ -436,6 +436,76 @@ def test_push_collider_repo_http_unreachable_endpoint(tmp_path: Path) -> None:
         assert cmd.execute() == os.EX_IOERR
 
 
+def test_push_filesystem_repo_duplicate_version_returns_ex_cantcreat(
+    tmp_path: Path, caplog
+) -> None:
+    """Publishing the same name/version twice returns EX_CANTCREAT with a clear message."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+
+    config = MagicMock()
+    config.repositories = {'local': repo}
+    context = MagicMock(spec=Context)
+    context.config = config
+
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    (source_dir / 'meson.build').write_text("project('my-lib', 'c')", encoding='utf-8')
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='my-lib', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    args = _push_args(repository='local', builddir=builddir)
+    assert Publish(args, context).execute() == os.EX_OK
+
+    result = Publish(args, context).execute()
+    assert result == os.EX_CANTCREAT
+    assert '1.0.0' in caplog.text
+    assert 'my-lib' in caplog.text
+    assert 'local' in caplog.text
+    assert 'Unpublish' in caplog.text
+    assert 'Failed to add package to repository' not in caplog.text
+
+
+def test_push_collider_repo_http_conflict_returns_ex_cantcreat(tmp_path: Path, caplog) -> None:
+    """Publishing a version that already exists on a remote collider repo returns EX_CANTCREAT."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    fs_repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+    server, thread, base_url = _start_push_server(fs_repo, token='secret')
+    try:
+        source_dir = tmp_path / 'src'
+        source_dir.mkdir()
+        (source_dir / 'meson.build').write_text("project('demo', 'c')", encoding='utf-8')
+        builddir = tmp_path / 'build'
+        _write_projectinfo(builddir, name='demo', version='2.0.0')
+        _write_mesoninfo(builddir, source_dir)
+
+        collider_repo = Collider(urllib.parse.urlparse(f'{base_url}/v2/'), {})
+        config = MagicMock()
+        config.repositories = {'remote': collider_repo}
+        context = MagicMock(spec=Context)
+        context.config = config
+
+        args = _push_args(repository='remote', builddir=builddir)
+        with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
+            assert Publish(args, context).execute() == os.EX_OK
+
+        with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
+            result = Publish(args, context).execute()
+        assert result == os.EX_CANTCREAT
+        assert '2.0.0' in caplog.text
+        assert 'demo' in caplog.text
+        assert 'remote' in caplog.text
+        assert 'Unpublish' in caplog.text
+        assert 'Failed to add package to repository' not in caplog.text
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
 def test_push_collider_repo_http_unexpected_status(tmp_path: Path) -> None:
     source_dir = tmp_path / 'src'
     source_dir.mkdir()


### PR DESCRIPTION
## Summary

- Introduces `PackageAlreadyExistsError(ValueError)` so the duplicate-version case is distinguished from generic I/O failures.
- `collider publish` now returns `EX_CANTCREAT` with an actionable message naming the package, version, and repository, instead of the opaque `"Failed to add package to repository"` at `EX_IOERR`.
- Covers both the filesystem (local `add_package`) and collider (HTTP 409) paths.
- `Serve.do_POST` now catches the typed exception instead of string-matching the message.

Closes #22

## Test plan

- [x] `test_push_filesystem_repo_duplicate_version_returns_ex_cantcreat`: publish same version twice to a filesystem repo -- asserts `EX_CANTCREAT`, actionable message present, generic error absent.
- [x] `test_push_collider_repo_http_conflict_returns_ex_cantcreat`: publish same version twice via HTTP collider repo (real server, 409 response) -- same assertions.
- [x] Both tests confirmed to **fail** against the old code and **pass** with the fix.