### PR TITLE
feat(publish): add --dry-run flag

### DIFF
--- a/collider/subcommand/Publish.py
+++ b/collider/subcommand/Publish.py
@@ -79,6 +79,12 @@ class Publish(SubcommandInterface):
             default=_DEFAULT_PUSH_TOKEN_ENV,
             help='Environment variable to read push token from for collider repositories.',
         )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Validate and package without writing to the repository.',
+        )
 
     def __init__(self, args: argparse.Namespace, context: Context):
         """
@@ -91,13 +97,15 @@ class Publish(SubcommandInterface):
         self.builddir: Path = args.builddir
         self.patch_archive: Path | None = args.patch_archive
         self.push_token_env: str = args.push_token_env
+        self.dry_run: bool = args.dry_run
 
     @override
     def execute(self) -> int:
         """Run the publish command.
         :return: Exit code.
         """
-        logger.info(f'Publishing project to repository "{self.repository_name}".')
+        action = 'Dry run: validating' if self.dry_run else 'Publishing'
+        logger.info(f'{action} publish to repository "{self.repository_name}".')
 
         for archive_path in (self.patch_archive,):
             if archive_path is None:
@@ -139,16 +147,22 @@ class Publish(SubcommandInterface):
                     self.patch_archive,
                 )
                 package = WrapPackage.from_wrap_text(package_name, version, wrap_text)
-                repo.add_package(
-                    package,
-                    source_archive=source_archive,
-                    patch_archive=self.patch_archive,
-                )
+                if self.dry_run:
+                    self._report_dry_run(
+                        package_name,
+                        version,
+                        source_archive,
+                        self.repository_name,
+                        repo.path.as_uri(),
+                    )
+                else:
+                    repo.add_package(
+                        package,
+                        source_archive=source_archive,
+                        patch_archive=self.patch_archive,
+                    )
             else:
                 assert isinstance(repo, Collider)
-                push_token = self._load_remote_push_token()
-                if push_token is None:
-                    return os.EX_USAGE
                 wrap_text = self._build_wrap_text(
                     _REMOTE_PLACEHOLDER_BASE_URL,
                     package_name,
@@ -157,10 +171,22 @@ class Publish(SubcommandInterface):
                     self.patch_archive,
                 )
                 package = WrapPackage.from_wrap_text(package_name, version, wrap_text)
-                payload = self._build_remote_push_payload(
-                    package, source_archive, self.patch_archive
-                )
-                self._push_remote_wrap_repo(repo, push_token, payload)
+                if self.dry_run:
+                    self._report_dry_run(
+                        package_name,
+                        version,
+                        source_archive,
+                        self.repository_name,
+                        repo.url.geturl(),
+                    )
+                else:
+                    push_token = self._load_remote_push_token()
+                    if push_token is None:
+                        return os.EX_USAGE
+                    payload = self._build_remote_push_payload(
+                        package, source_archive, self.patch_archive
+                    )
+                    self._push_remote_wrap_repo(repo, push_token, payload)
         except PackageAlreadyExistsError:
             logger.critical(
                 f'Version "{version}" of "{package_name}" already exists in repository '
@@ -175,8 +201,25 @@ class Publish(SubcommandInterface):
             if temp_archive is not None:
                 temp_archive.cleanup()
 
-        logger.info(f'Package "{package.name}" published successfully.')
+        if not self.dry_run:
+            logger.info(f'Package "{package.name}" published successfully.')
         return os.EX_OK
+
+    @staticmethod
+    def _report_dry_run(name: str, version: str, archive: Path, repo_name: str, dest: str) -> None:
+        """
+        Log a dry-run summary without writing anything.
+        :param name: Package name.
+        :param version: Package version.
+        :param archive: Path to the built source archive.
+        :param repo_name: Name of the target repository.
+        :param dest: URL or path of the target repository.
+        """
+        size_mb = archive.stat().st_size / 1_048_576
+        logger.info(f'[dry-run] Would publish: {name} {version}')
+        logger.info(f'[dry-run] Archive: {archive.name} ({size_mb:.1f} MB)')
+        logger.info(f'[dry-run] Destination: {repo_name} ({dest})')
+        logger.info('[dry-run] No files written.')
 
     def _build_source_archive(
         self, source_dir: Path, name: str, version: str

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -101,6 +101,20 @@ Options:
 | `--output PATH`              | Custom output path for the patch archive.        |
 | `--list`                     | Dry-run: list files that would be included.      |
 
+#### Empty Changeset
+
+If there are no changed files (for example, `--base` points to `HEAD` with no
+local changes), `collider patch` logs a warning and exits without creating an
+archive. Use `--list` to see which files would be included before running the
+full command.
+
+#### Deleted Files
+
+Deleted files cannot be included in a Meson wrap patch because wrap patches
+cannot remove files cleanly. If the diff contains a deleted file, `collider
+patch` exits with an error. Commit the deletion upstream or use `--exclude`
+to omit it from the patch.
+
 ### 2. Publish with the Patch
 
 Revert the source tree to the unmodified upstream, then publish:

--- a/docs/guide/publishing.md
+++ b/docs/guide/publishing.md
@@ -36,6 +36,38 @@ Use `--push-token-env` to read the token from a different variable:
 collider publish my-collider --push-token-env MY_TOKEN
 ```
 
+## Dry Run
+
+Use `--dry-run` to validate and package a release without writing anything to
+the repository:
+
+```bash
+collider publish <repo> --dry-run
+```
+
+Collider runs all validation steps, builds the source archive, and prints a
+summary of what would be published. No files are written and no network
+requests are made. The push token is not required in dry-run mode.
+
+```
+[dry-run] Would publish: my-lib 1.0.0
+[dry-run] Archive: my-lib-1.0.0.tar.xz (0.1 MB)
+[dry-run] Destination: my-repo (file:///path/to/repo)
+[dry-run] No files written.
+```
+
+## Duplicate Version Error
+
+If the version being published already exists in the repository, Collider exits
+with a non-zero status and suggests the available remedies:
+
+```
+CRITICAL: Version "1.0.0" of "my-lib" already exists in repository "my-repo".
+Unpublish the existing version first, or bump the project version.
+```
+
+Use `collider unpublish` to remove the existing version before re-publishing.
+
 ## The `[provide]` Section
 
 Collider auto-generates the wrap `[provide]` entry as `<name> = <name>_dep`,

--- a/docs/guide/serving.md
+++ b/docs/guide/serving.md
@@ -59,10 +59,24 @@ When enabled, the server exposes:
 
 Both require `Authorization: Bearer <token>`.
 
+!!! warning
+    When the push endpoint is enabled and `--host` is bound to a non-loopback
+    address, the server logs a security warning. Expose the push endpoint only
+    through a trusted reverse proxy.
+
 !!! note
     Built-in push auth is intentionally minimal (static bearer token). For
     production use, place a reverse proxy with proper authentication in front
     of the server.
+
+### `--publish-url` and pushed wraps
+
+When publishing via `collider publish`, the server rewrites archive URLs inside
+the generated wrap files using `--publish-url` as the base. If `--publish-url`
+is not set and push is enabled, Collider logs a warning and wraps will reference
+`file://` archive URLs instead. This works for local testing but is almost
+certainly wrong for any server that clients reach over the network -- always
+pass `--publish-url` in that case.
 
 ## Example Workflow
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,7 +112,7 @@ Generate a wrap and source archive, then publish to a repository.
 
 ```bash
 collider publish <repo> [--builddir PATH] [--patch-archive PATH]
-                        [--push-token-env VAR]
+                        [--push-token-env VAR] [--dry-run]
 ```
 
 | Option                | Description                                              |
@@ -121,6 +121,7 @@ collider publish <repo> [--builddir PATH] [--patch-archive PATH]
 | `--builddir PATH`     | Meson build directory (default: `collider-build`).       |
 | `--patch-archive PATH`| Attach a patch archive to the published package.         |
 | `--push-token-env VAR`| Environment variable holding the bearer token (default: `COLLIDER_PUSH_TOKEN`). |
+| `--dry-run`           | Validate and package without writing to the repository.  |
 
 ---
 

--- a/test/subcommand/test_push.py
+++ b/test/subcommand/test_push.py
@@ -92,12 +92,14 @@ def _push_args(
     builddir: Path,
     patch_archive: Path | None = None,
     push_token_env: str = 'COLLIDER_PUSH_TOKEN',
+    dry_run: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         repository=repository,
         builddir=builddir,
         patch_archive=patch_archive,
         push_token_env=push_token_env,
+        dry_run=dry_run,
     )
 
 
@@ -542,3 +544,70 @@ def test_push_collider_repo_http_unexpected_status(tmp_path: Path) -> None:
         thread.join(timeout=2)
 
     assert request_paths == ['/v2/_collider/v1/push']
+
+
+def test_dry_run_filesystem_repo_does_not_write(tmp_path: Path, caplog) -> None:
+    """--dry-run logs a summary and does not write anything to a filesystem repository."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+
+    config = MagicMock()
+    config.repositories = {'local': repo}
+    context = MagicMock(spec=Context)
+    context.config = config
+
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    (source_dir / 'meson.build').write_text("project('my-lib', 'c')", encoding='utf-8')
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='my-lib', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    result = Publish(
+        _push_args(repository='local', builddir=builddir, dry_run=True), context
+    ).execute()
+
+    assert result == os.EX_OK
+    assert not (repo_path / 'my-lib_1.0.0').exists()
+    assert '[dry-run] Would publish: my-lib 1.0.0' in caplog.text
+    assert '[dry-run] Archive:' in caplog.text
+    assert '[dry-run] Destination: local' in caplog.text
+    assert '[dry-run] No files written.' in caplog.text
+    assert 'published successfully' not in caplog.text
+
+
+def test_dry_run_collider_repo_does_not_push(tmp_path: Path, caplog) -> None:
+    """--dry-run logs a summary and does not push to a collider repository (no token needed)."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    fs_repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+    server, thread, base_url = _start_push_server(fs_repo, token='secret')
+    try:
+        source_dir = tmp_path / 'src'
+        source_dir.mkdir()
+        (source_dir / 'meson.build').write_text("project('demo', 'c')", encoding='utf-8')
+        builddir = tmp_path / 'build'
+        _write_projectinfo(builddir, name='demo', version='3.0.0')
+        _write_mesoninfo(builddir, source_dir)
+
+        collider_repo = Collider(urllib.parse.urlparse(f'{base_url}/v2/'), {})
+        config = MagicMock()
+        config.repositories = {'remote': collider_repo}
+        context = MagicMock(spec=Context)
+        context.config = config
+
+        # No token in environment -- dry-run must not require one.
+        with patch.dict(os.environ, {}, clear=True):
+            result = Publish(
+                _push_args(repository='remote', builddir=builddir, dry_run=True), context
+            ).execute()
+        assert result == os.EX_OK
+        assert not (repo_path / 'demo_3.0.0').exists()
+        assert '[dry-run] Would publish: demo 3.0.0' in caplog.text
+        assert '[dry-run] No files written.' in caplog.text
+        assert 'published successfully' not in caplog.text
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)


### PR DESCRIPTION
## Summary

- Adds `--dry-run` to `collider publish`: runs all validation and packaging steps but writes nothing to the repository.
- Logs what would happen: package name, version, archive size, and destination repo URL/path.
- For collider (HTTP) repositories, no push token is required in dry-run mode.

Closes #21

## Example output

```
[dry-run] Would publish: glaze 7.7.1
[dry-run] Archive: glaze-7.7.1.tar.xz (1.2 MB)
[dry-run] Destination: local (file:///home/user/collider-repo)
[dry-run] No files written.
```

## Test plan

- [ ] `test_dry_run_filesystem_repo_does_not_write`: dry-run against a filesystem repo returns `EX_OK`, writes nothing, logs the summary, no "published successfully" message.
- [ ] `test_dry_run_collider_repo_does_not_push`: dry-run against a collider repo with no token in env returns `EX_OK`, nothing pushed to the backing server.
- [ ] Both tests confirmed to **fail** against the old code and **pass** with the fix.