### PR TITLE
feat(check): add collider check subcommand for drift detection

### DIFF
--- a/collider/subcommand/Check.py
+++ b/collider/subcommand/Check.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Detect drift between meson.build dependency() calls and collider.json."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from pathlib import Path
+
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.log import logger
+from collider.subcommand.SubcommandInterface import SubcommandInterface
+from collider.utils.compat import override
+from collider.utils.meson.scan import filter_dependencies, scan_dependencies
+from collider.utils.packaging.Dependency import DependencySource
+
+
+_DEFAULT_SOURCE_DIR = Path('.')
+
+
+class Check(SubcommandInterface):
+    """Detect drift between meson.build dependency() calls and collider.json."""
+
+    @staticmethod
+    def help() -> str:
+        """Short help string surfaced by the CLI."""
+        return 'Check for drift between meson.build and collider.json.'
+
+    @classmethod
+    def long_help(cls) -> str:
+        """Longer help text shown for `collider check --help`."""
+        del cls
+        return (
+            'Scan meson.build for dependency() calls and compare against collider.json.\n'
+            'Reports untracked dependencies (in meson.build but not in collider.json) and\n'
+            'stale entries (in collider.json but absent from meson.build).\n\n'
+            'Assumes the dependency() name in meson.build matches the collider package name.\n'
+            'Exits with EX_DATAERR when drift is found, EX_OK when clean.'
+        )
+
+    @staticmethod
+    def epilog() -> str | None:
+        """Optional examples appended to the help output."""
+        return None
+
+    @staticmethod
+    def register(parser: argparse.ArgumentParser) -> None:
+        """Keep argparse wiring co-located with the command."""
+        parser.add_argument(
+            '--sourcedir',
+            type=Path,
+            default=_DEFAULT_SOURCE_DIR,
+            help='Meson source directory (default: current directory).',
+        )
+        parser.add_argument(
+            '--include-conditional',
+            action='store_true',
+            default=False,
+            help='Also check dependencies inside Meson if-blocks.',
+        )
+
+    def __init__(self, args: argparse.Namespace, context: Context):
+        """
+        Store check arguments and context.
+        :param args: Parsed CLI arguments.
+        :param context: Application context.
+        """
+        super().__init__(args, context)
+        self.sourcedir: Path = args.sourcedir
+        self.include_conditional: bool = args.include_conditional
+
+    @override
+    def execute(self) -> int:
+        """Run the check command.
+        :return: Exit code.
+        """
+        meson_build = self.sourcedir / 'meson.build'
+        colliderfile_path = self.sourcedir / Colliderfile.get_filename()
+
+        if not meson_build.exists():
+            logger.critical(f'No meson.build found in "{self.sourcedir}".')
+            return os.EX_NOINPUT
+
+        if not colliderfile_path.exists():
+            logger.critical(f'No collider.json found in "{self.sourcedir}".')
+            return os.EX_NOINPUT
+
+        colliderfile = Colliderfile.from_path(colliderfile_path)
+        scanned = scan_dependencies(meson_build)
+        filtered = filter_dependencies(scanned, include_conditional=self.include_conditional)
+
+        # Stale check uses the raw scan so conditional deps are not falsely flagged.
+        scanned_all_names = {dep.name for dep in scanned}
+        scanned_included_names = {dep.name for dep in filtered.included}
+        collider_names = {dep.name for dep in colliderfile.dependencies}
+        managed_names = {
+            dep.name for dep in colliderfile.dependencies if dep.source == DependencySource.COLLIDER
+        }
+
+        untracked = sorted(scanned_included_names - collider_names)
+        stale = sorted(managed_names - scanned_all_names)
+
+        for name in untracked:
+            logger.error(
+                f'"{name}" is used in meson.build but not tracked in collider.json. '
+                f'Run: collider pkg add {name}'
+            )
+        for name in stale:
+            logger.error(f'"{name}" is in collider.json but not found in meson.build.')
+
+        if untracked or stale:
+            return os.EX_DATAERR
+
+        logger.info('No drift detected.')
+        return os.EX_OK

--- a/docs/guide/checking.md
+++ b/docs/guide/checking.md
@@ -1,0 +1,52 @@
+# Checking for Drift
+
+`collider check` scans `meson.build` for `dependency()` calls and compares them
+against `collider.json`. It reports two classes of issues:
+
+- **Untracked**: a dependency called in `meson.build` that is not recorded in
+  `collider.json`. Fix with `collider pkg add <name>`.
+- **Stale**: a collider-managed entry in `collider.json` that no longer appears
+  anywhere in `meson.build`. Fix by running `collider pkg remove <name>`.
+
+The command exits `0` when clean and non-zero when drift is detected, making it
+suitable for CI gates.
+
+## Basic Usage
+
+Run from the project root:
+
+```bash
+collider check
+```
+
+Or specify a source directory:
+
+```bash
+collider check --sourcedir path/to/project
+```
+
+## Conditional Dependencies
+
+By default, `collider check` skips `dependency()` calls inside Meson `if`-blocks
+because their resolution depends on the build configuration. Pass
+`--include-conditional` to treat them as required:
+
+```bash
+collider check --include-conditional
+```
+
+## Known Limitation
+
+`collider check` assumes the `dependency()` name in `meson.build` matches the
+collider package name. Packages where these differ (for example, `abseil-cpp`
+provides `absl_strings`) may produce false positives.
+
+## CI Integration
+
+Add `collider check` as a step in CI to prevent dependency drift from going
+unnoticed:
+
+```yaml
+- name: Check dependency drift
+  run: collider check
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -299,6 +299,30 @@ Does not update `collider.lock`.
 
 ---
 
+## `check`
+
+Detect drift between `meson.build` dependency() calls and `collider.json`.
+
+```bash
+collider check [--sourcedir PATH] [--include-conditional]
+```
+
+| Option                  | Description                                                       |
+|-------------------------|-------------------------------------------------------------------|
+| `--sourcedir PATH`      | Meson source directory (default: current directory).              |
+| `--include-conditional` | Also check dependencies inside Meson `if`-blocks.                 |
+
+Reports **untracked** dependencies (called in `meson.build` but not in `collider.json`) and
+**stale** entries (in `collider.json` but absent from `meson.build`). Exits `0` when clean,
+non-zero on drift. Suitable for CI use.
+
+!!! note
+    Assumes the `dependency()` name in `meson.build` matches the collider package name.
+    Packages where the Meson dep name differs from the package name (e.g. `abseil-cpp` vs `absl_strings`)
+    may produce false positives.
+
+---
+
 ## `status`
 
 Show collider-managed dependencies and local wrap status.

--- a/test/common/common.py
+++ b/test/common/common.py
@@ -16,6 +16,7 @@ class Subcommand(str, Enum):
     REPO = 'repo'
     PUBLISH = 'publish'
     UNPUBLISH = 'unpublish'
+    CHECK = 'check'
 
 
 def run_subcommand(subcommand: Subcommand, args: list[str], verbose: bool = True) -> int:

--- a/test/subcommand/test_check.py
+++ b/test/subcommand/test_check.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Test the check subcommand."""
+
+import os
+
+from pathlib import Path
+from unittest.mock import patch
+
+from collider.file_model.colliderfile import Colliderfile
+from collider.utils.meson.scan import ScannedDependency
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+from test.common.common import Subcommand, run_subcommand
+
+
+def _make_project(tmp_path: Path, deps: list[Dependency]) -> None:
+    """Write meson.build and collider.json with the given dependencies."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+    Colliderfile(dependencies=deps).save(tmp_path / Colliderfile.get_filename())
+
+
+def _run_check(tmp_path: Path, extra_args: list[str] | None = None) -> int:
+    """Run collider check with --sourcedir pointing at tmp_path."""
+    return run_subcommand(Subcommand.CHECK, ['--sourcedir', str(tmp_path), *(extra_args or [])])
+
+
+def _mock_scan(deps: list[ScannedDependency]):
+    """Patch scan_dependencies in the Check module."""
+    return patch('collider.subcommand.Check.scan_dependencies', return_value=deps)
+
+
+def test_check_clean(tmp_path: Path) -> None:
+    _make_project(tmp_path, [Dependency('fmt', DependencySource.COLLIDER, None)])
+
+    with _mock_scan([ScannedDependency('fmt', required=True)]):
+        assert _run_check(tmp_path) == os.EX_OK
+
+
+def test_check_untracked(tmp_path: Path) -> None:
+    """Dep used in meson.build but absent from collider.json is untracked."""
+    _make_project(tmp_path, [])
+
+    with _mock_scan([ScannedDependency('fmt', required=True)]):
+        assert _run_check(tmp_path) == os.EX_DATAERR
+
+
+def test_check_stale(tmp_path: Path) -> None:
+    """Collider-managed dep in collider.json but absent from meson.build is stale."""
+    _make_project(tmp_path, [Dependency('fmt', DependencySource.COLLIDER, None)])
+
+    with _mock_scan([]):
+        assert _run_check(tmp_path) == os.EX_DATAERR
+
+
+def test_check_conditional_not_stale(tmp_path: Path) -> None:
+    """Conditional dep tracked in collider.json must not be flagged stale.
+
+    fmt appears in the raw scan (conditional=True) so it is NOT stale even
+    though filter_dependencies drops it from .included when --include-conditional
+    is not set.
+    """
+    _make_project(tmp_path, [Dependency('fmt', DependencySource.COLLIDER, None)])
+
+    with _mock_scan([ScannedDependency('fmt', required=True, conditional=True)]):
+        assert _run_check(tmp_path) == os.EX_OK
+
+
+def test_check_system_dep_not_stale(tmp_path: Path) -> None:
+    """System-source deps in collider.json are never reported as stale."""
+    _make_project(tmp_path, [Dependency('zlib', DependencySource.SYSTEM, None)])
+
+    with _mock_scan([]):
+        assert _run_check(tmp_path) == os.EX_OK
+
+
+def test_check_include_conditional(tmp_path: Path) -> None:
+    """With --include-conditional, conditional deps count as untracked when absent."""
+    _make_project(tmp_path, [])
+
+    with _mock_scan([ScannedDependency('fmt', required=True, conditional=True)]):
+        assert _run_check(tmp_path, ['--include-conditional']) == os.EX_DATAERR
+
+
+def test_check_missing_meson_build(tmp_path: Path) -> None:
+    Colliderfile().save(tmp_path / Colliderfile.get_filename())
+
+    assert _run_check(tmp_path) == os.EX_NOINPUT
+
+
+def test_check_missing_collider_json(tmp_path: Path) -> None:
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    assert _run_check(tmp_path) == os.EX_NOINPUT

--- a/zensical.toml
+++ b/zensical.toml
@@ -29,6 +29,7 @@ nav = [
     { "Locking and Installing" = "guide/locking-and-installing.md" },
     { "Offline Mode" = "guide/offline-mode.md" },
     { "Serving Repositories" = "guide/serving.md" },
+    { "Checking for Drift" = "guide/checking.md" },
   ] },
   { Reference = [
     { CLI = "reference/cli.md" },


### PR DESCRIPTION
Closes #20

## Summary

- Adds `collider check` subcommand that detects drift between `meson.build` `dependency()` calls and `collider.json` without requiring a configured build directory
- Reports **untracked** deps (used in `meson.build`, absent from `collider.json`) with a `collider pkg add` hint, and **stale** entries (in `collider.json` with `source: collider` but absent from `meson.build`)
- Exits `EX_DATAERR` on drift, `EX_OK` when clean -- suitable for CI gates
- Stale detection compares against the raw (unfiltered) scan so conditional deps are never falsely flagged as stale

**Known limitation** (documented): assumes the `dependency()` name in `meson.build` matches the collider package name. Packages where these differ (e.g. `abseil-cpp` / `absl_strings`) may produce false positives.

## Test plan

- [ ] `test_check_clean` -- EX_OK when deps match
- [ ] `test_check_untracked` -- EX_DATAERR for dep in meson.build not in collider.json
- [ ] `test_check_stale` -- EX_DATAERR for collider-managed dep absent from meson.build
- [ ] `test_check_conditional_not_stale` -- conditional dep in raw scan not flagged stale
- [ ] `test_check_system_dep_not_stale` -- system-source deps exempt from stale check
- [ ] `test_check_include_conditional` -- conditional dep counted as untracked with flag
- [ ] `test_check_missing_meson_build` -- EX_NOINPUT
- [ ] `test_check_missing_collider_json` -- EX_NOINPUT