### PR TITLE
feat(init): infer metadata from meson.build on init

### DIFF
--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -71,7 +71,7 @@ class Init(SubcommandInterface):
             else:
                 logger.warning('  license is not declared in meson.build.')
 
-        logger.warning('  description is not in meson.build -- set it manually in collider.json.')
+        logger.warning('  description: not in meson.build, set it manually in collider.json.')
 
     @override
     def execute(self) -> int:

--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -71,7 +71,7 @@ class Init(SubcommandInterface):
             else:
                 logger.warning('  license is not declared in meson.build.')
 
-        logger.warning('  description: not in meson.build, set it manually in collider.json.')
+        logger.warning('  description is not in meson.build, set it manually in collider.json.')
 
     @override
     def execute(self) -> int:

--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -71,7 +71,7 @@ class Init(SubcommandInterface):
             else:
                 logger.warning('  license is not declared in meson.build.')
 
-        logger.warning('  description is not in meson.build, set it manually in collider.json.')
+        logger.warning('  description has no equivalent in meson.build, set it manually in collider.json.')
 
     @override
     def execute(self) -> int:

--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -71,7 +71,7 @@ class Init(SubcommandInterface):
             else:
                 logger.warning('  license is not declared in meson.build.')
 
-        logger.warning('  description: fill it in collider.json.')
+        logger.warning('Set the description field in collider.json.')
 
     @override
     def execute(self) -> int:

--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -71,7 +71,7 @@ class Init(SubcommandInterface):
             else:
                 logger.warning('  license is not declared in meson.build.')
 
-        logger.warning('  description has no equivalent in meson.build, set it manually in collider.json.')
+        logger.warning('  description: fill it in collider.json.')
 
     @override
     def execute(self) -> int:

--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -15,6 +15,7 @@ from collider.file_model.colliderfile import Colliderfile
 from collider.log import logger
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
+from collider.utils.meson.scan import scan_project_info
 
 
 class Init(SubcommandInterface):
@@ -45,6 +46,33 @@ class Init(SubcommandInterface):
         # Init has no arguments; keep a stub for CLI discovery.
         del parser
 
+    @staticmethod
+    def _log_project_info(meson_path: Path) -> None:
+        """
+        Introspect meson.build and log what was found, warning on gaps.
+        :param meson_path: Path to the meson.build file.
+        """
+        project_info = scan_project_info(meson_path)
+        if project_info is not None:
+            name = project_info.get('descriptive_name', '')
+            version = project_info.get('version', '')
+            licenses = project_info.get('license', [])
+
+            logger.info(f'Found project "{name}" in meson.build.')
+
+            if version and version != 'undefined':
+                logger.info(f'  version : {version}')
+            else:
+                logger.warning('  version is not declared in meson.build.')
+
+            license_str = ', '.join(licenses) if licenses else ''
+            if license_str and license_str != 'unknown':
+                logger.info(f'  license : {license_str}')
+            else:
+                logger.warning('  license is not declared in meson.build.')
+
+        logger.warning('  description is not in meson.build -- set it manually in collider.json.')
+
     @override
     def execute(self) -> int:
         """Run the init command.
@@ -63,6 +91,7 @@ class Init(SubcommandInterface):
                 return os.EX_DATAERR
             logger.info('collider.json already exists.')
         else:
+            self._log_project_info(meson_path)
             # collider.json is the single source of truth for managed dependencies.
             Colliderfile().save(colliderfile_path)
             logger.info('Created collider.json.')

--- a/collider/utils/meson/scan.py
+++ b/collider/utils/meson/scan.py
@@ -47,6 +47,27 @@ def _ensure_meson_validated() -> None:
         globals()['_meson_validated'] = True
 
 
+def scan_project_info(meson_build: Path) -> Optional[dict]:
+    """
+    Run `meson introspect --projectinfo` on a meson.build file.
+
+    Best-effort: any failure (meson unavailable, parse error, etc.) returns None
+    so callers can degrade gracefully without special-casing every error type.
+
+    :param meson_build: Path to the meson.build file.
+    :return: Raw project info dict, or None on any failure.
+    """
+    try:
+        _ensure_meson_validated()
+        output = command.run(
+            ['meson', 'introspect', '--projectinfo', str(meson_build)],
+            capture=command.StdStream.STDOUT,
+        )
+        return json.loads(output) if output else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def scan_dependencies(meson_build: Path) -> list[ScannedDependency]:
     """
     Run `meson introspect --scan-dependencies` on a meson.build file.

--- a/test/subcommand/test_init.py
+++ b/test/subcommand/test_init.py
@@ -3,13 +3,22 @@
 
 """Test the init subcommand."""
 
+import logging
 import os
 
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from collider.file_model.colliderfile import Colliderfile
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from test.common.common import Subcommand, run_subcommand
+
+
+def _mock_project_info(info: dict | None):
+    """Patch scan_project_info in the Init module."""
+    return patch('collider.subcommand.Init.scan_project_info', return_value=info)
 
 
 def test_init_creates_colliderfile(tmp_path: Path) -> None:
@@ -18,7 +27,8 @@ def test_init_creates_colliderfile(tmp_path: Path) -> None:
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
     finally:
         os.chdir(cwd)
 
@@ -55,8 +65,91 @@ def test_init_requires_meson_build(tmp_path: Path) -> None:
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert run_subcommand(Subcommand.INIT, []) == os.EX_DATAERR
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_DATAERR
     finally:
         os.chdir(cwd)
 
     assert not (tmp_path / Colliderfile.get_filename()).exists()
+
+
+def test_init_logs_found_metadata(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """When introspection succeeds, name/version/license are logged as INFO."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    info = {'descriptive_name': 'mylib', 'version': '1.2.3', 'license': ['MIT']}
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(info), caplog.at_level(logging.INFO):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert 'mylib' in caplog.text
+    assert '1.2.3' in caplog.text
+    assert 'MIT' in caplog.text
+
+
+def test_init_warns_on_undefined_version(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """version == 'undefined' triggers a WARNING."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    info = {'descriptive_name': 'mylib', 'version': 'undefined', 'license': ['MIT']}
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(info), caplog.at_level(logging.WARNING):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert any('version' in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_init_warns_on_unknown_license(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """license == ['unknown'] triggers a WARNING."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    info = {'descriptive_name': 'mylib', 'version': '1.0.0', 'license': ['unknown']}
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(info), caplog.at_level(logging.WARNING):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert any('license' in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_init_always_warns_about_description(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """description warning is always emitted regardless of introspection result."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(None), caplog.at_level(logging.WARNING):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert any('description' in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_init_graceful_when_introspect_fails(tmp_path: Path) -> None:
+    """init succeeds and creates collider.json even when introspection returns None."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert (tmp_path / Colliderfile.get_filename()).exists()


### PR DESCRIPTION
Closes #19.

## Summary

- `collider init` now runs `meson introspect --projectinfo` on the existing `meson.build` when creating a new `collider.json`
- Logs found `name`, `version`, and `license` as INFO
- Emits WARNING for fields absent or set to meson defaults (`undefined` / `unknown`)
- Always emits WARNING that `description` must be set manually (it has no equivalent in `meson.build`)
- Introspection is best-effort: any failure (meson unavailable, parse error) degrades gracefully so `init` never blocks on it
- Idempotent: no introspection is attempted if `collider.json` already exists

## Example outputs

**All fields declared:**
```
Found project "test-project" in meson.build.
  version : 3.1.4
  license : Apache-2.0
WARNING: description is not in meson.build -- set it manually in collider.json.
Created collider.json.
```

**No version or license:**
```
Found project "minimal-project" in meson.build.
WARNING: version is not declared in meson.build.
WARNING: license is not declared in meson.build.
WARNING: description is not in meson.build -- set it manually in collider.json.
Created collider.json.
```

**Already initialized (idempotent):**
```
collider.json already exists.
```

## Test plan

- [ ] `test_init_logs_found_metadata`: name/version/license appear in INFO when introspection succeeds
- [ ] `test_init_warns_on_undefined_version`: WARNING emitted when version is `"undefined"`
- [ ] `test_init_warns_on_unknown_license`: WARNING emitted when license is `["unknown"]`
- [ ] `test_init_always_warns_about_description`: description WARNING always emitted
- [ ] `test_init_graceful_when_introspect_fails`: `EX_OK` and `collider.json` created even when introspection returns `None`
- [ ] All existing tests (`test_init_creates_colliderfile`, `test_init_is_idempotent`, `test_init_requires_meson_build`) still pass