### PR TITLE
feat(init): hint when meson.build is missing a license field

### DIFF
--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -15,6 +15,7 @@ from collider.file_model.colliderfile import Colliderfile
 from collider.log import logger
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
+from collider.utils.meson.scan import scan_project_info
 
 
 class Init(SubcommandInterface):
@@ -45,6 +46,31 @@ class Init(SubcommandInterface):
         # Init has no arguments; keep a stub for CLI discovery.
         del parser
 
+    @staticmethod
+    def _hint_missing_license(meson_path: Path) -> None:
+        """
+        Emit a hint when meson.build has no license field.
+
+        Missing license causes publish warnings; nudging at init time avoids
+        the user discovering the gap only when they first publish.
+
+        :param meson_path: Path to the meson.build file.
+        """
+        project_info = scan_project_info(meson_path)
+        if project_info is None:
+            return
+        licenses = project_info.get('license', [])
+        if not licenses or licenses == ['unknown']:
+            name = project_info.get('descriptive_name', 'mylib')
+            version = project_info.get('version', '1.0.0')
+            if version == 'undefined':
+                version = '1.0.0'
+            logger.warning(
+                'meson.build has no license field. '
+                'Add one to avoid warnings at publish time. '
+                f"Example: project('{name}', 'cpp', version: '{version}', license: 'MIT')"
+            )
+
     @override
     def execute(self) -> int:
         """Run the init command.
@@ -55,6 +81,8 @@ class Init(SubcommandInterface):
         if not meson_path.exists():
             logger.critical('No meson.build file found in current directory.')
             return os.EX_DATAERR
+
+        self._hint_missing_license(meson_path)
 
         colliderfile_path = project_root / Colliderfile.get_filename()
         if colliderfile_path.exists():

--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -50,10 +50,8 @@ class Init(SubcommandInterface):
     def _hint_missing_license(meson_path: Path) -> None:
         """
         Emit a hint when meson.build has no license field.
-
-        Missing license causes publish warnings; nudging at init time avoids
-        the user discovering the gap only when they first publish.
-
+        Missing license causes publish warnings; nudging at init time avoids the
+        user discovering the gap only when they first publish.
         :param meson_path: Path to the meson.build file.
         """
         project_info = scan_project_info(meson_path)

--- a/collider/utils/meson/scan.py
+++ b/collider/utils/meson/scan.py
@@ -50,10 +50,8 @@ def _ensure_meson_validated() -> None:
 def scan_project_info(meson_build: Path) -> Optional[dict]:
     """
     Run `meson introspect --projectinfo` on a meson.build file.
-
     Best-effort: any failure (meson unavailable, parse error, etc.) returns None
     so callers can degrade gracefully without special-casing every error type.
-
     :param meson_build: Path to the meson.build file.
     :return: Raw project info dict, or None on any failure.
     """

--- a/collider/utils/meson/scan.py
+++ b/collider/utils/meson/scan.py
@@ -47,6 +47,27 @@ def _ensure_meson_validated() -> None:
         globals()['_meson_validated'] = True
 
 
+def scan_project_info(meson_build: Path) -> Optional[dict]:
+    """
+    Run `meson introspect --projectinfo` on a meson.build file.
+
+    Best-effort: any failure (meson unavailable, parse error, etc.) returns None
+    so callers can degrade gracefully without special-casing every error type.
+
+    :param meson_build: Path to the meson.build file.
+    :return: Raw project info dict, or None on any failure.
+    """
+    try:
+        _ensure_meson_validated()
+        output = command.run(
+            ['meson', 'introspect', '--projectinfo', str(meson_build)],
+            capture=command.StdStream.STDOUT,
+        )
+        return json.loads(output) if output else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def scan_dependencies(meson_build: Path) -> list[ScannedDependency]:
     """
     Run `meson introspect --scan-dependencies` on a meson.build file.

--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -11,6 +11,14 @@ collider init
 This creates a `collider.json` file with an empty dependency list. Collider
 refuses to initialize outside a Meson project.
 
+If your `meson.build` `project()` call has no `license:` field, `collider init`
+emits a warning at setup time, because a missing license causes warnings on
+every `collider publish`. Add it now to avoid the noise later:
+
+```meson
+project('mylib', 'cpp', version: '1.0.0', license: 'MIT')
+```
+
 ## The `collider.json` File
 
 `collider.json` lives at the root of your Meson project, next to `meson.build`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,9 @@ collider init
 
 Refuses to run outside a Meson project (no `meson.build` found).
 
+If the `meson.build` `project()` declaration has no `license:` field, a hint is
+emitted at init time to avoid discovering the gap only when publishing.
+
 ---
 
 ## `setup`

--- a/test/subcommand/test_init.py
+++ b/test/subcommand/test_init.py
@@ -3,13 +3,22 @@
 
 """Test the init subcommand."""
 
+import logging
 import os
 
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from collider.file_model.colliderfile import Colliderfile
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from test.common.common import Subcommand, run_subcommand
+
+
+def _mock_project_info(info: dict | None):
+    """Patch scan_project_info in the Init module."""
+    return patch('collider.subcommand.Init.scan_project_info', return_value=info)
 
 
 def test_init_creates_colliderfile(tmp_path: Path) -> None:
@@ -18,7 +27,8 @@ def test_init_creates_colliderfile(tmp_path: Path) -> None:
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
     finally:
         os.chdir(cwd)
 
@@ -42,7 +52,8 @@ def test_init_is_idempotent(tmp_path: Path) -> None:
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
     finally:
         os.chdir(cwd)
 
@@ -60,3 +71,50 @@ def test_init_requires_meson_build(tmp_path: Path) -> None:
         os.chdir(cwd)
 
     assert not (tmp_path / Colliderfile.get_filename()).exists()
+
+
+def test_init_warns_when_license_missing(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A WARNING is emitted when meson.build has no license field."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    info = {'descriptive_name': 'demo', 'version': '1.0.0', 'license': ['unknown']}
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(info), caplog.at_level(logging.WARNING):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert any('license' in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_init_no_warning_when_license_set(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """No license WARNING when meson.build declares a license."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    info = {'descriptive_name': 'demo', 'version': '1.0.0', 'license': ['MIT']}
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(info), caplog.at_level(logging.WARNING):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert not any('license' in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_init_graceful_when_introspect_fails(tmp_path: Path) -> None:
+    """init succeeds even when introspection returns None."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert (tmp_path / Colliderfile.get_filename()).exists()

--- a/test/subcommand/test_init.py
+++ b/test/subcommand/test_init.py
@@ -118,3 +118,21 @@ def test_init_graceful_when_introspect_fails(tmp_path: Path) -> None:
         os.chdir(cwd)
 
     assert (tmp_path / Colliderfile.get_filename()).exists()
+
+
+def test_init_license_hint_falls_back_on_undefined_version(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An undefined project version falls back to 1.0.0 in the example hint."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    info = {'descriptive_name': 'demo', 'version': 'undefined', 'license': ['unknown']}
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(info), caplog.at_level(logging.WARNING):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert any("version: '1.0.0'" in r.message for r in caplog.records)

--- a/test/utils/meson/test_scan.py
+++ b/test/utils/meson/test_scan.py
@@ -248,6 +248,45 @@ def test_scan_passes_correct_args_to_meson(monkeypatch, tmp_path: Path) -> None:
     assert captured_args[3] == str(meson_build)
 
 
+def test_scan_project_info_parses_output(monkeypatch, tmp_path: Path) -> None:
+    """Valid introspect output is parsed and the projectinfo command is used."""
+    meson_build = tmp_path / 'meson.build'
+    meson_build.write_text("project('test', 'c')")
+    captured_args = []
+
+    def fake_run(args, **kwargs):
+        captured_args.extend(args)
+        return json.dumps({'descriptive_name': 'test', 'license': ['MIT']})
+
+    monkeypatch.setattr(scan.command, 'run', fake_run)
+    result = scan.scan_project_info(meson_build)
+
+    assert result == {'descriptive_name': 'test', 'license': ['MIT']}
+    assert captured_args[:3] == ['meson', 'introspect', '--projectinfo']
+    assert captured_args[3] == str(meson_build)
+
+
+def test_scan_project_info_returns_none_on_failure(monkeypatch, tmp_path: Path) -> None:
+    """Any introspection error degrades to None instead of raising."""
+    meson_build = tmp_path / 'meson.build'
+    meson_build.write_text("project('test', 'c')")
+
+    def fake_run(args, **kwargs):
+        raise subprocess.CalledProcessError(1, args)
+
+    monkeypatch.setattr(scan.command, 'run', fake_run)
+    assert scan.scan_project_info(meson_build) is None
+
+
+def test_scan_project_info_returns_none_on_empty_output(monkeypatch, tmp_path: Path) -> None:
+    """Empty introspect output yields None rather than a parse error."""
+    meson_build = tmp_path / 'meson.build'
+    meson_build.write_text("project('test', 'c')")
+
+    monkeypatch.setattr(scan.command, 'run', lambda args, **kwargs: '')
+    assert scan.scan_project_info(meson_build) is None
+
+
 def test_filter_default_includes_required(_all_deps) -> None:
     """Required dependencies are included by default."""
     result = scan.filter_dependencies(_all_deps)


### PR DESCRIPTION
Closes #18.

## Summary

`collider init` now runs `meson introspect --projectinfo` and emits a **WARNING** with a concrete example when the `meson.build` `project()` call has no `license:` field.

Without this, a missing license only surfaces as a repeated warning at every `collider publish`, which the user has to trace back to the root cause themselves.

Introspection is best-effort: any failure (meson unavailable, parse error) degrades gracefully so `init` never blocks.

## Example

**No license declared:**
```
WARNING  meson.build has no license field. Add one to avoid warnings at publish time. Example: project('libassert', 'cpp', version: '2.2.1', license: 'MIT')
Created collider.json.
```

**License declared: no warning emitted.**

## Test plan

- [ ] `test_init_warns_when_license_missing`: WARNING with `license` in message when license is `["unknown"]`
- [ ] `test_init_no_warning_when_license_set`: no WARNING when license is declared
- [ ] `test_init_graceful_when_introspect_fails`: `EX_OK` and `collider.json` created even when introspection returns `None`
- [ ] All existing init tests pass