### PR TITLE
fix: address critical and high severity review findings

### DIFF
--- a/collider/cache.py
+++ b/collider/cache.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from collider.log import logger
 from collider.Package import WrapPackage
+from collider.utils.core import assert_safe_path_segment, is_safe_path_segment
 from collider.utils.fs import atomic_write_text
 from collider.utils.meson.scan import ScannedDependency
 from collider.utils.network import DEFAULT_NETWORK_TIMEOUT
@@ -38,6 +39,9 @@ class WrapCache:
 
     def store_wrap(self, package: WrapPackage) -> Path:
         """Persist a wrap so installs can proceed without network access."""
+        # Name and version come from repository metadata and become a path here.
+        assert_safe_path_segment(package.name)
+        assert_safe_path_segment(package.version, 'version')
         self.wraps_dir.mkdir(parents=True, exist_ok=True)
         wrap_path = self.wraps_dir / f'{package.name}_{package.version}.wrap'
         # Wrap cache decouples installs from repository availability.
@@ -46,6 +50,10 @@ class WrapCache:
 
     def load_wrap(self, name: str, version: str) -> Optional[WrapPackage]:
         """Load a cached wrap to reuse the same validation rules."""
+        # An unsafe name can never have been cached (writes reject it), so treat
+        # it as a miss rather than touching a traversed path or raising.
+        if not (is_safe_path_segment(name) and is_safe_path_segment(version)):
+            return None
         wrap_path = self.wraps_dir / f'{name}_{version}.wrap'
         if not wrap_path.exists():
             return None
@@ -87,6 +95,9 @@ class WrapCache:
         return sorted(versions)
 
     def _archive_cached(self, expected_hash: str, filename: str) -> bool:
+        # The hash comes from untrusted wrap metadata and becomes a path segment.
+        if not is_safe_path_segment(expected_hash):
+            return False
         safe_name = Path(filename).name
         cached_path = self.archives_dir / f'{expected_hash}-{safe_name}'
         return cached_path.exists()
@@ -118,6 +129,9 @@ class WrapCache:
         scanned: list[ScannedDependency],
     ) -> Path:
         """Persist dependency scan results so future resolutions skip introspection."""
+        # Name and version come from repository metadata and become a path here.
+        assert_safe_path_segment(name)
+        assert_safe_path_segment(version, 'version')
         self.scans_dir.mkdir(parents=True, exist_ok=True)
         scan_path = self.scans_dir / f'{name}_{version}.json'
         data = [
@@ -135,6 +149,9 @@ class WrapCache:
 
     def load_scan(self, name: str, version: str) -> Optional[list[ScannedDependency]]:
         """Load cached scan results, returning None on miss or corruption."""
+        # Unsafe names are never cached; treat as a miss without touching disk.
+        if not (is_safe_path_segment(name) and is_safe_path_segment(version)):
+            return None
         scan_path = self.scans_dir / f'{name}_{version}.json'
         if not scan_path.exists():
             return None
@@ -177,6 +194,8 @@ class WrapCache:
         self, package: WrapPackage, subprojects_dir: Path, offline: bool
     ) -> None:
         """Populate Meson packagecache so wrap resolution can stay offline."""
+        # Reject unsafe names before callers install the package into subprojects.
+        assert_safe_path_segment(package.name)
         packagecache = subprojects_dir / 'packagecache'
         packagecache.mkdir(parents=True, exist_ok=True)
 
@@ -202,6 +221,8 @@ class WrapCache:
 
     def _ensure_archive(self, url: str, filename: str, expected_hash: str, offline: bool) -> Path:
         """Resolve archives into the cache while enforcing hashes and protocols."""
+        # The hash comes from untrusted wrap metadata and becomes a path segment.
+        assert_safe_path_segment(expected_hash, 'hash')
         self.archives_dir.mkdir(parents=True, exist_ok=True)
         # Use the basename to avoid path traversal from wrap metadata.
         safe_name = Path(filename).name

--- a/collider/file_model/FileModelInterface.py
+++ b/collider/file_model/FileModelInterface.py
@@ -164,7 +164,12 @@ class FileModelInterface(ABC):
         return json.dumps(self.as_dict())
 
     def as_file(self) -> IO[str]:
-        """Provide a temp file handle for consumers that need a path."""
+        """
+        Provide a rewound temp file handle for use as a context manager.
+        The backing file is removed when the handle is closed, so use it within a
+        `with` block and read it before the block exits.
+        :return: An open, rewound temp file handle.
+        """
         tmp = tempfile.NamedTemporaryFile(
             'w+',
             encoding='UTF-8',

--- a/collider/repository/entries.py
+++ b/collider/repository/entries.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+from collider.log import logger
+from collider.utils.core import is_safe_path_segment
 from collider.utils.meson.infoTypes import WrapDbReleases
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key, parse_repo_key
@@ -66,10 +68,18 @@ def packages_from_releases(
     """
     packages: dict[RepoKey, RepoPackageEntry] = {}
     for name, entry in releases.items():
+        # Names and versions from an untrusted releases.json become filesystem
+        # paths downstream; drop unsafe ones at the index boundary.
+        if not is_safe_path_segment(name):
+            logger.debug(f'Skipping release with unsafe name: "{name}".')
+            continue
         versions = entry.get('versions', [])
         dependency_names = entry.get('dependency_names')
         if dependency_names is not None:
             dependency_names = sorted(set(dependency_names))
         for version in versions:
+            if not is_safe_path_segment(version):
+                logger.debug(f'Skipping unsafe version "{version}" for "{name}".')
+                continue
             add_wrap_entry(packages, name, version, dependency_names)
     return packages

--- a/collider/repository/implementation/Filesystem.py
+++ b/collider/repository/implementation/Filesystem.py
@@ -14,6 +14,7 @@ from typing import Optional
 from collider.log import logger
 from collider.Package import WrapPackage, _load_wrap_section, get_provide_names
 from collider.repository.entries import RepoPackageEntry, add_wrap_entry
+from collider.utils.core import assert_safe_path_segment
 from collider.utils.fs import atomic_write_text
 from collider.utils.packaging import compute_file_hash
 from collider.utils.packaging.PackageType import PackageType
@@ -274,8 +275,4 @@ class Filesystem(RepositoryInterface):
 
     @staticmethod
     def _safe_package_segment(value: str, key: str) -> str:
-        if not value:
-            raise ValueError(f'Package {key} must not be empty.')
-        if value in ('.', '..') or Path(value).name != value or '\\' in value or '\x00' in value:
-            raise ValueError(f'Package {key} must be a safe path segment.')
-        return value
+        return assert_safe_path_segment(value, key)

--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -16,6 +16,7 @@ from collider.log import logger
 from collider.Package import WrapPackage
 from collider.repository.entries import RepoPackageEntry, packages_from_releases
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.utils.core import assert_safe_path_segment
 from collider.utils.fs import atomic_write_text
 from collider.utils.meson.infoTypes import WrapDbReleasesEntry
 from collider.utils.network import DEFAULT_NETWORK_TIMEOUT
@@ -27,7 +28,10 @@ _RELEASES_TTL_SECONDS = 300
 
 
 def _get_pkg_wrap_url(url: urllib.parse.ParseResult, package: RepoPackageEntry) -> str:
-    path = f'{package.name}_{package.version}/{package.name}.wrap'
+    # Name and version come from untrusted releases.json and shape the request path.
+    name = assert_safe_path_segment(package.name)
+    version = assert_safe_path_segment(package.version, 'version')
+    path = f'{name}_{version}/{name}.wrap'
     return urllib.parse.urljoin(url.geturl(), path)
 
 

--- a/collider/subcommand/Install.py
+++ b/collider/subcommand/Install.py
@@ -28,6 +28,7 @@ from collider.repository.entries import RepoPackageEntry
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
+from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson import SUBPROJECTS_DIR
 from collider.utils.meson.project import validate_meson_project_cwd
 from collider.utils.packaging.Dependency import DependencySource
@@ -435,6 +436,13 @@ class Install(SubcommandInterface):
         :param repo_key: Encoded repo key.
         :return: WrapPackage on success, None on failure.
         """
+        # Names from repository metadata become subproject and cache paths.
+        try:
+            assert_safe_path_segment(entry.name)
+        except ValueError as e:
+            logger.critical(str(e))
+            return None
+
         if self.offline and repo.requires_network():
             package = self.context.cache.load_wrap(entry.name, entry.version)
             if package is None:

--- a/collider/subcommand/Patch.py
+++ b/collider/subcommand/Patch.py
@@ -188,8 +188,12 @@ Examples:
             return None
 
         if self.include_uncommitted:
-            # HEAD vs working tree and index; plus untracked.
-            status = self._run_git(['diff', '--name-status', 'HEAD'], cwd=source_dir)
+            # base revision vs working tree and index (defaults to HEAD); plus untracked.
+            # --no-renames keeps output deterministic regardless of git's rename config:
+            # a rename becomes add + delete, and the delete is caught below.
+            status = self._run_git(
+                ['diff', '--name-status', '--no-renames', self.base_rev], cwd=source_dir
+            )
             if status.returncode != 0:
                 logger.critical(f'Git diff failed: {status.stderr or status.stdout}')
                 return None
@@ -206,7 +210,8 @@ Examples:
                     logger.critical(
                         f'Deleted file "{path}" cannot be included in a Meson wrap patch; '
                         'wrap patches cannot remove files cleanly. Commit the deletion or '
-                        'exclude it from the patch.'
+                        'exclude it from the patch. (A rename is reported as a deletion of '
+                        'the old path plus an addition of the new one.)'
                     )
                     return None
                 paths_from_diff.append(path)
@@ -224,8 +229,11 @@ Examples:
                     paths_from_diff.append(p)
             return paths_from_diff
 
-        # Committed changes only: base..HEAD.
-        status = self._run_git(['diff', '--name-status', f'{self.base_rev}..HEAD'], cwd=source_dir)
+        # Committed changes only: base..HEAD. --no-renames so renames surface as add +
+        # delete deterministically and the delete is rejected below.
+        status = self._run_git(
+            ['diff', '--name-status', '--no-renames', f'{self.base_rev}..HEAD'], cwd=source_dir
+        )
         if status.returncode != 0:
             logger.critical(f'Git diff failed: {status.stderr or status.stdout}')
             return None
@@ -241,7 +249,8 @@ Examples:
             if status_code == 'D':
                 logger.critical(
                     f'Deleted file "{path}" cannot be included in a Meson wrap patch; '
-                    'wrap patches cannot remove files cleanly.'
+                    'wrap patches cannot remove files cleanly. (A rename is reported as a '
+                    'deletion of the old path plus an addition of the new one.)'
                 )
                 return None
             paths.append(path)

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -29,6 +29,7 @@ from collider.repository.entries import RepoPackageEntry
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
+from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson import SUBPROJECTS_DIR
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from collider.utils.packaging.PackageType import PackageType
@@ -144,15 +145,16 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
             return os.EX_NOINPUT
 
         colliderfile_path = Path.cwd().joinpath(Colliderfile.get_filename())
-        if colliderfile_path.exists():
+        colliderfile_existed = colliderfile_path.exists()
+        if colliderfile_existed:
             if colliderfile_path.is_dir():
                 logger.critical('collider.json exists but is a directory.')
                 return os.EX_DATAERR
             colliderfile = Colliderfile.from_path(colliderfile_path)
         else:
-            colliderfile = Colliderfile()
-            colliderfile.save(colliderfile_path)
-            logger.info('Created collider.json.')
+            # Defer writing collider.json until the dependency is actually added,
+            # so a failed install never leaves a stray empty file behind.
+            colliderfile = Colliderfile(path=colliderfile_path)
         version_spec_str = self._resolve_version_specifier_text(colliderfile)
 
         wrap_path = Path.cwd() / SUBPROJECTS_DIR / f'{self.package_name}.wrap'
@@ -171,6 +173,8 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
                     RepoPackageEntry(self.package_name, '', PackageType.WRAP),
                     version_spec_str,
                 )
+                if not colliderfile_existed:
+                    logger.info('Created collider.json.')
                 if Path.cwd().joinpath(Lockfile.get_filename()).exists():
                     logger.warning(
                         f'collider.lock was not updated for "{self.package_name}"; '
@@ -223,6 +227,8 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
             return transitive_result
 
         self._add_dependency(colliderfile, newest_entry, version_spec_str)
+        if not colliderfile_existed:
+            logger.info('Created collider.json.')
         self._warn_if_lockfile_stale(newest_entry, package)
         return os.EX_OK
 
@@ -364,6 +370,13 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
         :param quiet: Log install progress at DEBUG instead of INFO.
         :return: Installed WrapPackage on success, None on failure.
         """
+        # Names from repository metadata become subproject and cache paths.
+        try:
+            assert_safe_path_segment(entry.name)
+        except ValueError as e:
+            logger.critical(str(e))
+            return None
+
         log = logger.debug if quiet else logger.info
         log(f'Installing package "{entry.name}" (version {entry.version})...')
         logger.debug(f'Fetching package "{repo_key}".')

--- a/collider/subcommand/pkg/Upgrade.py
+++ b/collider/subcommand/pkg/Upgrade.py
@@ -27,6 +27,7 @@ from collider.repository.entries import RepoPackageEntry
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
+from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson import SUBPROJECTS_DIR
 from collider.utils.meson.project import validate_meson_project_cwd
 from collider.utils.packaging.Dependency import DependencySource
@@ -232,6 +233,13 @@ class Upgrade(SubcommandInterface):
         repo_key: RepoKey,
     ) -> Optional[WrapPackage]:
         """Fetch the chosen package, honoring offline mode."""
+        # Names from repository metadata become subproject and cache paths.
+        try:
+            assert_safe_path_segment(entry.name)
+        except ValueError as e:
+            logger.critical(str(e))
+            return None
+
         if self.offline and repo.requires_network():
             package = self.context.cache.load_wrap(entry.name, entry.version)
             if package is None:

--- a/collider/utils/core.py
+++ b/collider/utils/core.py
@@ -12,12 +12,49 @@ import inspect
 import pkgutil
 import types
 
+from pathlib import Path
 from typing import Optional, Type, TypeVar
 
 from collider.log import logger
 
 
 T = TypeVar('T', bound=type)
+
+
+def is_safe_path_segment(value: str) -> bool:
+    """
+    Report whether a value is safe to use as a single filesystem path segment.
+    Rejects empty values, '.'/'..', and anything containing a separator or NUL,
+    so untrusted names/versions cannot escape their target directory.
+    :param value: Value to check.
+    :return: True when the value is a safe path segment.
+    """
+    if not value:
+        return False
+    return (
+        value not in ('.', '..')
+        and Path(value).name == value
+        and '\\' not in value
+        and '\x00' not in value
+    )
+
+
+def assert_safe_path_segment(value: str, kind: str = 'name') -> str:
+    """
+    Validate that an untrusted value is safe to use as a single path segment.
+    Package names and versions come from repository metadata and are turned into
+    wrap and subproject paths, so reject anything that could escape the target
+    directory before it reaches the filesystem.
+    :param value: Value to validate.
+    :param kind: Label used in error messages, e.g. "name" or "version".
+    :return: The validated value unchanged.
+    :raises ValueError: When the value is empty or not a safe path segment.
+    """
+    if not value:
+        raise ValueError(f'Package {kind} must not be empty.')
+    if not is_safe_path_segment(value):
+        raise ValueError(f'Package {kind} must be a safe path segment.')
+    return value
 
 
 def discover_plugins(

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -27,6 +27,7 @@ from tqdm import tqdm
 from collider.cache import WrapCache
 from collider.log import logger
 from collider.repository import search_packages
+from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson.scan import (
     ScannedDependency,
     filter_dependencies,
@@ -37,7 +38,9 @@ from collider.utils.packaging.repo_key import make_repo_key
 
 
 if TYPE_CHECKING:
+    from collider.repository.entries import RepoPackageEntry
     from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+    from collider.utils.packaging.types import RepoKey
 
 
 @dataclass(frozen=True)
@@ -77,10 +80,14 @@ class Candidate:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Candidate):
             return NotImplemented
-        return self.name == other.name and self.version == other.version
+        return (
+            self.name == other.name
+            and self.version == other.version
+            and self.repo_name == other.repo_name
+        )
 
     def __hash__(self) -> int:
-        return hash((self.name, self.version))
+        return hash((self.name, self.version, self.repo_name))
 
     def __repr__(self) -> str:
         return f'Candidate({self.name!r}, {self.version!r}, {self.repo_name!r})'
@@ -168,29 +175,85 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
             re.compile(f'^{re.escape(identifier)}$'),
         )
 
+        # Prefer stable releases; only consider prereleases when nothing stable
+        # satisfies the constraints, so packages that ship only prereleases stay
+        # installable without surprising stable resolutions.
+        candidates = self._collect_matches(all_matches, reqs, bad, allow_prereleases=False)
+        if not candidates:
+            candidates = self._collect_matches(all_matches, reqs, bad, allow_prereleases=True)
+
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return [c for _, c in candidates]
+
+    @staticmethod
+    def _matches_requirements(
+        version: str, reqs: list[Requirement], allow_prereleases: bool
+    ) -> bool:
+        """
+        Check a version against every requirement's specifier.
+        :param version: Candidate version string.
+        :param reqs: Requirements that must all be satisfied.
+        :param allow_prereleases: Allow prereleases even when a specifier targets stable releases.
+        :return: True when the version satisfies all requirements.
+        """
+        # prereleases=None lets each specifier apply its own default, so explicit
+        # prerelease constraints keep working; True forces the prerelease fallback.
+        prereleases = True if allow_prereleases else None
+        return all(
+            req.version_spec is None or req.version_spec.contains(version, prereleases=prereleases)
+            for req in reqs
+        )
+
+    def _collect_matches(
+        self,
+        all_matches: Mapping[str, Mapping[RepoKey, RepoPackageEntry]],
+        reqs: list[Requirement],
+        bad: set[Candidate],
+        allow_prereleases: bool,
+    ) -> list[tuple[packaging.version.Version, Candidate]]:
+        """
+        Build the list of candidates that satisfy the requirements.
+        :param all_matches: Packages found per repository for the identifier.
+        :param reqs: Requirements every candidate must satisfy.
+        :param bad: Candidates marked incompatible by the resolver.
+        :param allow_prereleases: Whether prereleases may satisfy stable specifiers.
+        :return: List of (parsed version, candidate) tuples.
+        """
         candidates: list[tuple[packaging.version.Version, Candidate]] = []
         for repo_name, pkgs in all_matches.items():
             for _key, entry in pkgs.items():
+                try:
+                    # Names and versions from repository metadata become cache and
+                    # subproject paths downstream; never resolve unsafe segments.
+                    assert_safe_path_segment(entry.name)
+                    assert_safe_path_segment(entry.version, 'version')
+                except ValueError:
+                    logger.debug(
+                        f'Skipping package with unsafe name or version: '
+                        f'"{entry.name}" "{entry.version}".'
+                    )
+                    continue
+
                 try:
                     parsed = packaging.version.parse(entry.version)
                 except InvalidVersion:
                     continue
 
-                if any(r.version_spec and not r.version_spec.contains(entry.version) for r in reqs):
+                if not self._matches_requirements(entry.version, reqs, allow_prereleases):
                     continue
 
                 cand = Candidate(entry.name, entry.version, repo_name)
                 if cand in bad:
                     continue
                 candidates.append((parsed, cand))
-
-        candidates.sort(key=lambda x: x[0], reverse=True)
-        return [c for _, c in candidates]
+        return candidates
 
     def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
         if requirement.version_spec is None:
             return True
-        return requirement.version_spec.contains(candidate.version)
+        # Allow prereleases here so a prerelease pin chosen by find_matches still
+        # satisfies stable specifiers; the version range itself is still enforced.
+        return requirement.version_spec.contains(candidate.version, prereleases=True)
 
     def get_dependencies(self, candidate: Candidate) -> list[Requirement]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ exclude_lines = [
     "raise AssertionError",
     "raise NotImplementedError",
     "if __name__ == '__main__':",
+    "if TYPE_CHECKING:",
     "@abstractmethod"
 ]
 

--- a/test/cache/test_cache.py
+++ b/test/cache/test_cache.py
@@ -113,6 +113,15 @@ def test_wrap_cache_has_package(tmp_path: Path):
     assert cache.has_package('foo', '1.0.0') is True
 
 
+def test_wrap_cache_has_package_rejects_unsafe_hash(tmp_path: Path):
+    """has_package treats an unsafe source_hash as not cached instead of crashing."""
+    cache = WrapCache(tmp_path / 'cache')
+    package = WrapPackage.from_wrap_text('foo', '1.0.0', _wrap_text('../../evil'))
+
+    cache.store_wrap(package)
+    assert cache.has_package('foo', '1.0.0') is False
+
+
 def test_wrap_cache_prepare_packagecache_downloads(tmp_path: Path, monkeypatch):
     cache = WrapCache(tmp_path / 'cache')
     subprojects = tmp_path / 'project' / 'subprojects'

--- a/test/cache/test_cache.py
+++ b/test/cache/test_cache.py
@@ -46,6 +46,56 @@ def test_wrap_cache_store_and_load(tmp_path: Path):
     assert loaded.source_url == 'https://example.com/foo.tar.xz'
 
 
+def test_wrap_cache_store_rejects_unsafe_name(tmp_path: Path):
+    """store_wrap refuses a traversal package name instead of writing outside the cache."""
+    cache = WrapCache(tmp_path / 'cache')
+    package = WrapPackage.from_wrap_text('../evil', '1.0.0', _wrap_text('deadbeef'))
+
+    with pytest.raises(ValueError):
+        cache.store_wrap(package)
+
+    assert not (tmp_path / 'evil_1.0.0.wrap').exists()
+
+
+def test_wrap_cache_store_scan_rejects_unsafe_name(tmp_path: Path):
+    """store_scan refuses a traversal name instead of writing outside the scans dir."""
+    from collider.utils.meson.scan import ScannedDependency
+
+    cache = WrapCache(tmp_path / 'cache')
+
+    with pytest.raises(ValueError):
+        cache.store_scan('../../evil', '1.0.0', [ScannedDependency(name='zlib', required=True)])
+
+    assert not (tmp_path / 'evil_1.0.0.json').exists()
+    assert not (tmp_path.parent / 'evil_1.0.0.json').exists()
+
+
+def test_wrap_cache_load_returns_none_on_unsafe_name(tmp_path: Path):
+    """Reads treat a traversal name as a cache miss (no crash) instead of raising."""
+    cache = WrapCache(tmp_path / 'cache')
+    assert cache.load_wrap('../../evil', '1.0.0') is None
+    assert cache.load_scan('../../evil', '1.0.0') is None
+    assert cache.has_package('../../evil', '1.0.0') is False
+
+
+def test_wrap_cache_ensure_archive_rejects_unsafe_hash(tmp_path: Path):
+    """A traversal source_hash cannot make the archive path escape the cache."""
+    cache = WrapCache(tmp_path / 'cache')
+    package = WrapPackage.from_wrap_text(
+        'foo',
+        '1.0.0',
+        '[wrap-file]\n'
+        'source_url=https://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        'source_hash=../../evil\n',
+    )
+
+    with pytest.raises(ValueError):
+        cache.prepare_packagecache(package, tmp_path / 'subprojects', offline=True)
+
+    assert not (tmp_path.parent / 'evil-foo.tar.xz').exists()
+
+
 def test_wrap_cache_has_package(tmp_path: Path):
     cache = WrapCache(tmp_path / 'cache')
 

--- a/test/file_model/test_file_model.py
+++ b/test/file_model/test_file_model.py
@@ -154,6 +154,16 @@ def test_mock_file_model_as_file():
     assert json.loads(json_str) == {'name': 'test_as_file', 'version': 7}
 
 
+def test_mock_file_model_as_file_cleans_up_on_close():
+    """The backing temp file is removed when the handle is closed."""
+    model = MockFileModel(name='test_cleanup', version=8)
+    tmp_file = model.as_file()
+    path = Path(tmp_file.name)
+    assert path.exists()
+    tmp_file.close()
+    assert not path.exists()
+
+
 def test_mock_file_model_set_path_invalid():
     """Test _set_path with a directory."""
     model = MockFileModel(name='test')

--- a/test/repository/implementation/test_mesonwrapdb.py
+++ b/test/repository/implementation/test_mesonwrapdb.py
@@ -125,6 +125,36 @@ def test_wrap_releases_to_packages_empty_versions():
     assert packages == {}
 
 
+def test_wrap_releases_to_packages_skips_unsafe_name_and_version():
+    """Traversal names/versions from an untrusted releases.json are dropped at the boundary."""
+    releases = {
+        '../../evil': {'versions': ['1.0.0']},
+        'foo': {'versions': ['1.0.0', '../../evil']},
+    }
+    packages = _wrap_releases_to_packages(releases)
+
+    names = {entry.name for entry in packages.values()}
+    versions = {entry.version for entry in packages.values()}
+    assert names == {'foo'}
+    assert versions == {'1.0.0'}
+
+
+def test_wrap_url_builder_rejects_unsafe_name():
+    """A traversal name cannot redirect the fetch path outside the repo API prefix."""
+    url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
+    entry = RepoPackageEntry('../../../etc', '1.2.3', PackageType.WRAP)
+    with pytest.raises(ValueError):
+        _get_pkg_wrap_url(url, entry)
+
+
+def test_wrap_url_builder_rejects_unsafe_version():
+    """A traversal version cannot redirect the fetch path outside the repo API prefix."""
+    url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
+    entry = RepoPackageEntry('foo', '../../secret', PackageType.WRAP)
+    with pytest.raises(ValueError):
+        _get_pkg_wrap_url(url, entry)
+
+
 def test_wrap_url_builders():
     url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
     entry = RepoPackageEntry('foo', '1.2.3', PackageType.WRAP)

--- a/test/subcommand/test_install.py
+++ b/test/subcommand/test_install.py
@@ -503,6 +503,20 @@ def test_install_does_not_warn_when_lockfile_already_matches(
     assert 'run "collider lock" to refresh it' not in caplog.text
 
 
+def test_install_fetch_package_rejects_unsafe_name(tmp_path: Path) -> None:
+    """_fetch_package returns None when the entry name is not a safe path segment."""
+    from collider.subcommand.Install import Install
+
+    repo = MagicMock(spec=RepositoryInterface)
+    context = _make_context(tmp_path, repo)
+    install = Install(argparse.Namespace(offline=False), context)
+
+    entry = RepoPackageEntry('../evil', '1.0.0', PackageType.WRAP)
+    repo_key = make_repo_key('../evil', '1.0.0', PackageType.WRAP)
+
+    assert install._fetch_package(entry, repo, repo_key) is None
+
+
 def test_install_adds_dependency_without_version(tmp_path: Path, monkeypatch) -> None:
     """New dependency in collider.json has no version pinned."""
     _init_project(tmp_path)

--- a/test/subcommand/test_patch.py
+++ b/test/subcommand/test_patch.py
@@ -187,6 +187,99 @@ def test_patch_deleted_file_errors(tmp_path: Path) -> None:
     assert result == os.EX_DATAERR
 
 
+def test_patch_uncommitted_uses_base_revision(tmp_path: Path) -> None:
+    """--base is honored in the default uncommitted mode, diffing against base, not HEAD."""
+    source_dir = _init_meson_project(tmp_path)
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    diff_args: list[list[str]] = []
+
+    def mock_run_git(self, args: list, cwd: Path, capture: bool = True):
+        if args[:2] == ['rev-parse', '--show-toplevel']:
+            return MagicMock(returncode=0, stdout=str(cwd), stderr='')
+        if args[:2] == ['diff', '--name-status']:
+            diff_args.append(args)
+            return MagicMock(returncode=0, stdout='M\tmodified.txt\n', stderr='')
+        if args[:3] == ['ls-files', '--others', '--exclude-standard']:
+            return MagicMock(returncode=0, stdout='', stderr='')
+        return MagicMock(returncode=1, stdout='', stderr='')
+
+    context = MagicMock(spec=Context)
+    args = _patch_args(builddir=builddir, base='v1.0', include_uncommitted=True, list_only=True)
+    cmd = Patch(args, context)
+
+    with (
+        patch('pathlib.Path.cwd', return_value=tmp_path),
+        patch.object(Patch, '_run_git', mock_run_git),
+    ):
+        result = cmd.execute()
+
+    assert result == os.EX_OK
+    assert diff_args == [['diff', '--name-status', '--no-renames', 'v1.0']]
+
+
+def test_patch_committed_mode_uses_base_range_and_no_renames(tmp_path: Path) -> None:
+    """Committed-only mode diffs base..HEAD and passes --no-renames for determinism."""
+    source_dir = _init_meson_project(tmp_path)
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    diff_args: list[list[str]] = []
+
+    def mock_run_git(self, args: list, cwd: Path, capture: bool = True):
+        if args[:2] == ['rev-parse', '--show-toplevel']:
+            return MagicMock(returncode=0, stdout=str(cwd), stderr='')
+        if args[:2] == ['diff', '--name-status']:
+            diff_args.append(args)
+            return MagicMock(returncode=0, stdout='M\tmodified.txt\n', stderr='')
+        return MagicMock(returncode=1, stdout='', stderr='')
+
+    context = MagicMock(spec=Context)
+    args = _patch_args(builddir=builddir, base='v1.0', include_uncommitted=False, list_only=True)
+    cmd = Patch(args, context)
+
+    with (
+        patch('pathlib.Path.cwd', return_value=tmp_path),
+        patch.object(Patch, '_run_git', mock_run_git),
+    ):
+        result = cmd.execute()
+
+    assert result == os.EX_OK
+    assert diff_args == [['diff', '--name-status', '--no-renames', 'v1.0..HEAD']]
+
+
+def test_patch_renamed_file_reported_as_deletion_errors(tmp_path: Path) -> None:
+    """With --no-renames a rename surfaces as a delete of the old path and is rejected."""
+    source_dir = _init_meson_project(tmp_path)
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    def mock_run_git(self, args: list, cwd: Path, capture: bool = True):
+        if args[:2] == ['rev-parse', '--show-toplevel']:
+            return MagicMock(returncode=0, stdout=str(cwd), stderr='')
+        if args[:2] == ['diff', '--name-status']:
+            # --no-renames reports a rename as add(new) + delete(old).
+            return MagicMock(returncode=0, stdout='A\tnew.txt\nD\told.txt\n', stderr='')
+        if args[:3] == ['ls-files', '--others', '--exclude-standard']:
+            return MagicMock(returncode=0, stdout='', stderr='')
+        return MagicMock(returncode=1, stdout='', stderr='')
+
+    context = MagicMock(spec=Context)
+    args = _patch_args(builddir=builddir)
+    cmd = Patch(args, context)
+
+    with (
+        patch('pathlib.Path.cwd', return_value=tmp_path),
+        patch.object(Patch, '_run_git', mock_run_git),
+    ):
+        result = cmd.execute()
+    assert result == os.EX_DATAERR
+
+
 def test_patch_list_only_prints_paths(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     source_dir = _init_meson_project(tmp_path)
     builddir = tmp_path / 'build'

--- a/test/subcommand/test_transitive.py
+++ b/test/subcommand/test_transitive.py
@@ -845,6 +845,61 @@ def test_add_already_installed_transitive_becomes_direct_dependency(
     assert 'already installed; adding it to collider.json as a direct dependency' in caplog.text
 
 
+def test_add_already_installed_transitive_creates_colliderfile(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Promoting an installed transitive wrap creates collider.json when it is missing."""
+    from collider.file_model.lockfile import LockedPackage, Lockfile
+
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n')
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir(exist_ok=True)
+    (subprojects / 'protobuf.wrap').write_text('[wrap-file]\n')
+
+    lockfile = Lockfile(
+        packages={
+            'protobuf': LockedPackage(
+                version='25.2-4',
+                wrap_hash='sha256:' + '0' * 64,
+                origin='https://wrapdb.example.com/v2/',
+            )
+        }
+    )
+    lockfile.save(tmp_path / Lockfile.get_filename())
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    context = _make_context(tmp_path, {'repo1': repo})
+
+    args = argparse.Namespace(
+        package='protobuf',
+        offline=False,
+        version=None,
+        include=None,
+        exclude=None,
+        include_conditional=False,
+        exclude_optional=False,
+        force=False,
+    )
+    cmd = Add(args, context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = cmd.execute()
+    finally:
+        os.chdir(cwd)
+
+    assert result == os.EX_OK
+    repo.get_package.assert_not_called()
+    colliderfile_path = tmp_path / Colliderfile.get_filename()
+    assert colliderfile_path.exists()
+    colliderfile = Colliderfile.from_path(colliderfile_path)
+    assert [dep.name for dep in colliderfile.dependencies] == ['protobuf']
+    assert 'Created collider.json.' in caplog.text
+
+
 def test_add_force_reinstalls(tmp_path: Path, monkeypatch) -> None:
     """pkg add --force removes old artifacts and reinstalls the package."""
     _init_project(tmp_path)

--- a/test/subcommand/test_transitive.py
+++ b/test/subcommand/test_transitive.py
@@ -227,6 +227,100 @@ def test_add_creates_colliderfile_when_missing(tmp_path: Path, monkeypatch) -> N
     assert [dep.name for dep in colliderfile.dependencies] == ['grpc']
 
 
+def test_add_does_not_create_colliderfile_on_failure(tmp_path: Path) -> None:
+    """A failed add must not leave a stray collider.json behind."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    repo.requires_network.return_value = False
+    context = _make_context(tmp_path, {'repo1': repo})
+
+    args = argparse.Namespace(
+        package='ghost',
+        offline=False,
+        version=None,
+        include=None,
+        exclude=None,
+        include_conditional=False,
+        exclude_optional=False,
+        force=False,
+    )
+    cmd = Add(args, context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch('collider.subcommand.pkg.Add.search_packages', return_value={}):
+            result = cmd.execute()
+    finally:
+        os.chdir(cwd)
+
+    assert result == os.EX_UNAVAILABLE
+    assert not (tmp_path / Colliderfile.get_filename()).exists()
+
+
+def test_transitive_rejects_unsafe_package_name(tmp_path: Path, monkeypatch) -> None:
+    """A traversal transitive package name is rejected without writing outside subprojects."""
+    _init_project(tmp_path)
+
+    grpc_pkg, grpc_content = _make_package('grpc', '1.59.1')
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    repo.requires_network.return_value = False
+    repo.get_package.return_value = grpc_pkg
+    context = _make_context(tmp_path, {'repo1': repo})
+
+    monkeypatch.setattr(
+        urllib.request, 'urlopen', lambda url, **kwargs: _DummyResponse(grpc_content)
+    )
+
+    resolved_mapping = {
+        'grpc': Candidate('grpc', '1.59.1', 'repo1'),
+        '../../evil': Candidate('../../evil', '1.0.0', 'repo1'),
+    }
+
+    args = argparse.Namespace(
+        package='grpc',
+        offline=False,
+        version=None,
+        include=None,
+        exclude=None,
+        include_conditional=False,
+        exclude_optional=False,
+        force=False,
+    )
+    cmd = Add(args, context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with (
+            patch('collider.subcommand.pkg.Add.search_packages') as mock_search,
+            patch(
+                'collider.subcommand.pkg.Add.resolve_dependencies',
+                return_value=_make_resolution_result(resolved_mapping),
+            ),
+            patch(
+                'collider.subcommand.pkg.Add.build_dep_name_index',
+                return_value={'evil': '../../evil'},
+            ),
+        ):
+            grpc_key = make_repo_key('grpc', '1.59.1', PackageType.WRAP)
+            grpc_entry = RepoPackageEntry('grpc', '1.59.1', PackageType.WRAP)
+            mock_search.return_value = {'repo1': {grpc_key: grpc_entry}}
+            result = cmd.execute()
+    finally:
+        os.chdir(cwd)
+
+    assert result == os.EX_IOERR
+    # The traversal target must not be created outside subprojects.
+    assert not (tmp_path.parent / 'evil.wrap').exists()
+    # A failed transitive install does not record the root dependency.
+    colliderfile = Colliderfile.from_path(tmp_path / Colliderfile.get_filename())
+    assert [dep.name for dep in colliderfile.dependencies] == []
+
+
 def test_transitive_add_skips_system_deps(
     tmp_path: Path, monkeypatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/test/subcommand/test_upgrade.py
+++ b/test/subcommand/test_upgrade.py
@@ -419,6 +419,18 @@ def test_upgrade_skips_invalid_versions(tmp_path: Path, monkeypatch) -> None:
     ) == package.wrap_text
 
 
+def test_upgrade_fetch_package_rejects_unsafe_name(tmp_path: Path) -> None:
+    """_fetch_package returns None when the entry name is not a safe path segment."""
+    repo = MagicMock(spec=RepositoryInterface)
+    context = _make_context(tmp_path, repo)
+    cmd = Upgrade(argparse.Namespace(package=None, version=None, offline=False), context)
+
+    entry = RepoPackageEntry('../evil', '1.0.0', PackageType.WRAP)
+    repo_key = make_repo_key('../evil', '1.0.0', PackageType.WRAP)
+
+    assert cmd._fetch_package(entry, repo, repo_key) is None
+
+
 def test_upgrade_fetch_failure_returns_ioerr(tmp_path: Path) -> None:
     """Upgrade fails cleanly when fetching the selected package fails."""
     _init_project(

--- a/test/utils/packaging/test_resolver.py
+++ b/test/utils/packaging/test_resolver.py
@@ -201,11 +201,41 @@ def test_candidate_inequality_different_version() -> None:
 
 
 def test_candidate_hash_consistent_with_equality() -> None:
-    """Equal candidates (name+version) have the same hash regardless of repo."""
+    """Equal candidates (name+version+repo) share a hash and collapse in sets."""
     c1 = Candidate('zlib', '1.3.1', 'local')
-    c2 = Candidate('zlib', '1.3.1', 'remote')
+    c2 = Candidate('zlib', '1.3.1', 'local')
     assert hash(c1) == hash(c2)
     assert len({c1, c2}) == 1
+
+
+def test_candidate_distinct_by_repo() -> None:
+    """Same name and version from different repos are distinct candidates."""
+    c1 = Candidate('zlib', '1.3.1', 'local')
+    c2 = Candidate('zlib', '1.3.1', 'remote')
+    assert c1 != c2
+    assert len({c1, c2}) == 2
+
+
+def test_candidate_incompatibility_scoped_to_repo() -> None:
+    """Marking one repo's candidate incompatible does not drop another repo's identical version."""
+    repo1 = _make_repo(_make_packages(('zlib', '1.3.1', ['zlib'])))
+    repo2 = _make_repo(_make_packages(('zlib', '1.3.1', ['zlib'])))
+    repos = {'repo1': repo1, 'repo2': repo2}
+    provider = ColliderProvider(repos, build_dep_name_index(repos))
+
+    req = Requirement('zlib')
+    bad = Candidate('zlib', '1.3.1', 'repo1')
+    identifier = provider.identify(req)
+    matches = list(
+        provider.find_matches(
+            identifier=identifier,
+            requirements={identifier: [req]},
+            incompatibilities={identifier: [bad]},
+        )
+    )
+
+    repo_names = {m.repo_name for m in matches}
+    assert repo_names == {'repo2'}
 
 
 def test_candidate_repr() -> None:
@@ -350,6 +380,61 @@ def test_provider_find_matches_filters_incompatibilities() -> None:
 
     assert len(matches) == 1
     assert matches[0].version == '1.2.0'
+
+
+def test_provider_find_matches_excludes_prerelease_when_stable_exists() -> None:
+    """A prerelease is not offered when a stable version satisfies the constraint."""
+    packages = _make_packages(
+        ('zlib', '1.3.1', ['zlib']),
+        ('zlib', '2.0.0rc1', ['zlib']),
+    )
+    repo = _make_repo(packages)
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos))
+
+    req = Requirement('zlib', '>=1.0')
+    identifier = provider.identify(req)
+    matches = list(
+        provider.find_matches(
+            identifier=identifier,
+            requirements={identifier: [req]},
+            incompatibilities={identifier: []},
+        )
+    )
+
+    assert [m.version for m in matches] == ['1.3.1']
+
+
+def test_provider_find_matches_falls_back_to_prerelease_when_only_option() -> None:
+    """A prerelease is offered when no stable version satisfies the constraint."""
+    packages = _make_packages(('zlib', '2.0.0rc1', ['zlib']))
+    repo = _make_repo(packages)
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos))
+
+    req = Requirement('zlib', '>=1.0')
+    identifier = provider.identify(req)
+    matches = list(
+        provider.find_matches(
+            identifier=identifier,
+            requirements={identifier: [req]},
+            incompatibilities={identifier: []},
+        )
+    )
+
+    assert [m.version for m in matches] == ['2.0.0rc1']
+
+
+def test_provider_is_satisfied_by_accepts_prerelease_for_stable_spec() -> None:
+    """A prerelease candidate satisfies a stable specifier; the version range still applies."""
+    packages = _make_packages(('zlib', '2.0.0rc1', ['zlib']))
+    repo = _make_repo(packages)
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos))
+
+    req = Requirement('zlib', '>=1.0')
+    assert provider.is_satisfied_by(req, Candidate('zlib', '2.0.0rc1', 'local')) is True
+    assert provider.is_satisfied_by(req, Candidate('zlib', '0.9.0rc1', 'local')) is False
 
 
 def test_provider_find_matches_skips_invalid_versions() -> None:

--- a/test/utils/packaging/test_resolver.py
+++ b/test/utils/packaging/test_resolver.py
@@ -301,6 +301,27 @@ def test_provider_find_matches_returns_candidates() -> None:
     assert versions[1] == '1.2.0'
 
 
+def test_provider_find_matches_skips_unsafe_version() -> None:
+    """find_matches drops entries whose version is not a safe path segment."""
+    packages: dict = {}
+    add_wrap_entry(packages, 'foo', '../evil', None)
+    repo = _make_repo(packages)
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos))
+
+    req = Requirement('foo')
+    identifier = provider.identify(req)
+    matches = list(
+        provider.find_matches(
+            identifier=identifier,
+            requirements={identifier: [req]},
+            incompatibilities={identifier: []},
+        )
+    )
+
+    assert matches == []
+
+
 def test_provider_is_satisfied_by_no_constraint() -> None:
     """Any candidate satisfies a requirement with no version spec."""
     packages = _make_packages(('zlib', '1.3.1', ['zlib']))

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -120,3 +120,8 @@ def test_assert_safe_path_segment_rejects_unsafe(value: str) -> None:
     """Empty, traversal, separator, and NUL values are rejected."""
     with pytest.raises(ValueError):
         core.assert_safe_path_segment(value)
+
+
+def test_is_safe_path_segment_rejects_empty() -> None:
+    """An empty string is reported as an unsafe path segment."""
+    assert core.is_safe_path_segment('') is False

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -104,3 +104,19 @@ def test_run_command_cwd_uses_current_directory(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(target_dir)
     stdout = command.run(['pwd'], capture=StdStream.STDOUT)
     assert stdout == str(target_dir)
+
+
+def test_assert_safe_path_segment_accepts_normal_names() -> None:
+    """Ordinary package names and versions pass through unchanged."""
+    assert core.assert_safe_path_segment('abseil-cpp') == 'abseil-cpp'
+    assert core.assert_safe_path_segment('1.3.1', 'version') == '1.3.1'
+
+
+@pytest.mark.parametrize(
+    'value',
+    ['', '.', '..', '../evil', 'a/b', 'a\\b', 'foo\x00bar'],
+)
+def test_assert_safe_path_segment_rejects_unsafe(value: str) -> None:
+    """Empty, traversal, separator, and NUL values are rejected."""
+    with pytest.raises(ValueError):
+        core.assert_safe_path_segment(value)


### PR DESCRIPTION
## Summary

Fixes the critical and high severity findings from a full code review, plus one
documentation item. Developed and verified with TDD; the test suite passes only
as a whole, so the changes ship in a single PR.

| Issue | Severity | Fix |
|-------|----------|-----|
| #30 | Critical | Path-traversal hardening for untrusted package name/version/hash |
| #29 | High | `pkg add` no longer leaves a stray `collider.json` on failure |
| #31 | High | `patch` uses `--no-renames` and the requested base revision |
| #32 | High | Resolver candidates stay distinct across repositories |
| #33 | High | Prerelease-only packages now resolve (stable preferred) |
| #34 | Low  | Documented `as_file()` temp-file lifecycle + regression test |

## Security note (#30)

Names/versions come from untrusted `releases.json` and become filesystem paths.
Primary defense is at the untrusted-index boundary (`packages_from_releases`
skips unsafe entries); per-sink guards are defense in depth -- writes raise,
reads return a graceful miss so `pkg search` / `pkg info` iteration never
crashes.

## Verification

- pytest: 597 passed, 89.59% coverage (>= 80% required)
- ruff format + check: clean
- ty: clean
- pylint: 10.00/10
- Local CI (`act`): `lint` and `pytest` (3.10 + 3.13) jobs succeed

Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
