### PR TITLE
fix(ci): make docs deploy resilient to a dirty server tree

### DIFF
--- a/.ci/deploy-docs.sh
+++ b/.ci/deploy-docs.sh
@@ -14,10 +14,15 @@ export HOME=/var/lib/collider
 
 cd "$REPO_DIR"
 git -c safe.directory="$REPO_DIR" fetch --prune origin
-git -c safe.directory="$REPO_DIR" checkout -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"
+# Force the checkout so a dirty working tree never blocks the deploy. Without -f,
+# a locally modified file (e.g. uv.lock) aborts checkout before reset --hard can
+# clean it, deadlocking every subsequent deploy.
+git -c safe.directory="$REPO_DIR" checkout -f -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"
 git -c safe.directory="$REPO_DIR" reset --hard "origin/$DEPLOY_BRANCH"
 mkdir -p "$UV_CACHE_DIR" "$UV_DATA_DIR" "$UV_PYTHON_INSTALL_DIR"
-uv sync --group docs
+# --frozen keeps the committed lock authoritative: never rewrite uv.lock on the
+# server, and fail loudly if it drifts from pyproject instead of silently doing so.
+uv sync --frozen --group docs
 uv run --group docs zensical build --clean
 
 mkdir -p "$WEB_ROOT"


### PR DESCRIPTION
## Summary

Fixes the recurring `deploy-docs` CI failure on `main`.

## Root cause (verified on the server)

The deploy aborted at:

```
git checkout -B main origin/main
error: Your local changes to the following files would be overwritten by checkout:
	uv.lock
Aborting
```

`uv sync` (without `--frozen`) rewrote `uv.lock` in the server's `/collider-app`
working tree (collider-wraps `1.0.1` -> `1.2.0`). On the next run, `git checkout -B`
refused to overwrite that local change and aborted **before** the `reset --hard`
on the next line could clean it. Every subsequent deploy then deadlocked, leaving
the server 10 commits behind.

## Fix

- `git checkout -f -B ...`: force the checkout so a dirty tree can never block the
  deploy. The existing `reset --hard` then guarantees an exact match to origin.
- `uv sync --frozen --group docs`: keep the committed lock authoritative; never
  rewrite `uv.lock` on the server, and fail loudly if it drifts from pyproject.

## Verification

- Recovered the stuck server manually (`checkout -f` + `reset --hard` to current main).
- Confirmed `uv sync --frozen --group docs` builds and leaves the tree clean.
- Triggered the real `deploy-docs` workflow on main: it now succeeds and the docs
  site is published.
