### PR TITLE
test: exit-code contract tests for all CLI commands

### DIFF
--- a/test/contract/test_check_exit_codes.py
+++ b/test/contract/test_check_exit_codes.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider "check" command."""
+
+import os
+
+from pathlib import Path
+from unittest.mock import patch
+
+from collider.file_model.colliderfile import Colliderfile
+from collider.utils.meson.meson import MesonUnavailableError
+from collider.utils.meson.scan import ScannedDependency
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+from test.common.common import Subcommand, run_subcommand
+
+
+def _make_project(tmp_path: Path, deps: list[Dependency]) -> None:
+    """Write meson.build and collider.json with the given dependencies."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+    Colliderfile(dependencies=deps).save(tmp_path / Colliderfile.get_filename())
+
+
+def _run_check(tmp_path: Path) -> int:
+    """Run collider check with --sourcedir pointing at tmp_path."""
+    return run_subcommand(Subcommand.CHECK, ['--sourcedir', str(tmp_path)])
+
+
+def test_check_ex_noinput_missing_meson_build(tmp_path: Path) -> None:
+    """check returns EX_NOINPUT when meson.build is missing from --sourcedir."""
+    # collider.json present so the meson.build guard fires, not the collider.json one.
+    Colliderfile().save(tmp_path / Colliderfile.get_filename())
+
+    assert _run_check(tmp_path) == os.EX_NOINPUT
+
+
+def test_check_ex_dataerr_untracked_dependency(tmp_path: Path) -> None:
+    """check returns EX_DATAERR when a scanned dep is untracked in collider.json."""
+    _make_project(tmp_path, [])
+
+    with patch(
+        'collider.subcommand.Check.scan_dependencies',
+        return_value=[ScannedDependency('fmt', required=True)],
+    ):
+        assert _run_check(tmp_path) == os.EX_DATAERR
+
+
+def test_check_ex_ok_clean(tmp_path: Path) -> None:
+    """check returns EX_OK when scanned deps match collider.json with no drift."""
+    _make_project(tmp_path, [Dependency('fmt', DependencySource.COLLIDER, None)])
+
+    with patch(
+        'collider.subcommand.Check.scan_dependencies',
+        return_value=[ScannedDependency('fmt', required=True)],
+    ):
+        assert _run_check(tmp_path) == os.EX_OK
+
+
+def test_check_ex_unavailable_meson_validation_fails(tmp_path: Path) -> None:
+    """check returns EX_UNAVAILABLE when the Meson binary fails validation."""
+    _make_project(tmp_path, [Dependency('fmt', DependencySource.COLLIDER, None)])
+
+    # Reset the per-process cache so a prior successful validation does not short-circuit.
+    with (
+        patch('collider.utils.meson.scan._meson_validated', False),
+        patch(
+            'collider.utils.meson.scan._meson_mod.validate',
+            side_effect=MesonUnavailableError('meson unavailable'),
+        ),
+    ):
+        assert _run_check(tmp_path) == os.EX_UNAVAILABLE

--- a/test/contract/test_init_exit_codes.py
+++ b/test/contract/test_init_exit_codes.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `collider init` command."""
+
+import os
+
+from pathlib import Path
+from unittest.mock import patch
+
+from collider.file_model.colliderfile import Colliderfile
+from test.common.common import Subcommand, run_subcommand
+
+
+def _mock_project_info(info: dict | None):
+    """Patch scan_project_info in the Init module to avoid invoking real meson."""
+    return patch('collider.subcommand.Init.scan_project_info', return_value=info)
+
+
+def test_init_ex_ok_meson_build_present(tmp_path: Path) -> None:
+    """`collider init` returns EX_OK when meson.build exists and collider.json is ensured."""
+    (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with _mock_project_info(None):
+            assert run_subcommand(Subcommand.INIT, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert (tmp_path / Colliderfile.get_filename()).exists()
+
+
+def test_init_ex_dataerr_missing_meson_build(tmp_path: Path) -> None:
+    """`collider init` returns EX_DATAERR when no meson.build exists in cwd (current behavior)."""
+    # Current behavior: missing meson.build returns EX_DATAERR (65), not EX_NOINPUT.
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert run_subcommand(Subcommand.INIT, []) == os.EX_DATAERR
+    finally:
+        os.chdir(cwd)
+
+    assert not (tmp_path / Colliderfile.get_filename()).exists()

--- a/test/contract/test_install_exit_codes.py
+++ b/test/contract/test_install_exit_codes.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `collider install` command."""
+
+import argparse
+import hashlib
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.file_model.lockfile import LockedPackage, Lockfile, compute_wrap_hash
+from collider.Package import WrapPackage
+from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.subcommand.Install import Install
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+
+
+ORIGIN = 'https://wrapdb.example.com/v2'
+
+
+def _wrap_text(source_hash: str) -> str:
+    """Build a minimal wrap-file body with the given source hash."""
+    return (
+        '[wrap-file]\n'
+        'source_url=https://example.com/pkg.tar.xz\n'
+        'source_filename=pkg.tar.xz\n'
+        f'source_hash={source_hash}\n'
+    )
+
+
+def _make_package(name: str, version: str, content: bytes) -> WrapPackage:
+    """Build a WrapPackage whose source hash matches the given content."""
+    content_hash = hashlib.sha256(content).hexdigest()
+    return WrapPackage.from_wrap_text(name, version, _wrap_text(content_hash))
+
+
+def _init_project(tmp_path: Path, dependencies: list[Dependency] | None = None) -> None:
+    """Write a meson.build and a collider.json so the cwd is a valid Meson project."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n')
+    Colliderfile(dependencies=dependencies or []).save(tmp_path / Colliderfile.get_filename())
+
+
+def _make_context(tmp_path: Path, repo: RepositoryInterface) -> Context:
+    """Build a Context whose single configured repository is the given mock."""
+    config = MagicMock()
+    config.repositories = {'repo1': repo}
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+
+def _run(cmd: Install, tmp_path: Path) -> int:
+    """Execute the command from within the project directory and restore cwd."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        return cmd.execute()
+    finally:
+        os.chdir(cwd)
+
+
+def test_install_ex_noinput_missing_colliderfile(tmp_path: Path) -> None:
+    """`collider install` returns EX_NOINPUT when collider.json is absent from the project."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n')  # No collider.json.
+
+    context = _make_context(tmp_path, MagicMock(spec=RepositoryInterface))
+    cmd = Install(argparse.Namespace(offline=False, frozen=False), context)
+
+    assert _run(cmd, tmp_path) == os.EX_NOINPUT
+
+
+def test_install_ex_dataerr_invalid_locked_constraint(tmp_path: Path) -> None:
+    """`collider install` returns EX_DATAERR when a locked dep has an unparseable constraint."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('foo', DependencySource.COLLIDER, 'not-a-specifier')],
+    )
+    Lockfile(
+        dependencies={
+            'foo': LockedPackage(
+                version='1.0.0',
+                wrap_hash=compute_wrap_hash(_wrap_text('deadbeef' * 8)),
+                origin=ORIGIN,
+            ),
+        },
+    ).save(tmp_path / Lockfile.get_filename())
+
+    context = _make_context(tmp_path, MagicMock(spec=RepositoryInterface))
+    cmd = Install(argparse.Namespace(offline=False, frozen=False), context)
+
+    assert _run(cmd, tmp_path) == os.EX_DATAERR
+
+
+def test_install_ex_config_origin_repo_not_configured(tmp_path: Path) -> None:
+    """`collider install` returns EX_CONFIG when no configured repo matches the locked origin."""
+    package = _make_package('pkg', '1.0.0', b'payload')
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('pkg', DependencySource.COLLIDER, None)],
+    )
+    Lockfile(
+        dependencies={
+            'pkg': LockedPackage(
+                version='1.0.0',
+                wrap_hash=compute_wrap_hash(package.wrap_text),
+                origin='https://missing.example.com/',
+            ),
+        },
+    ).save(tmp_path / Lockfile.get_filename())
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.origin_url = ORIGIN  # Does not match the locked origin.
+    repo.requires_network.return_value = False
+    context = _make_context(tmp_path, repo)
+    cmd = Install(argparse.Namespace(offline=False, frozen=False), context)
+
+    assert _run(cmd, tmp_path) == os.EX_CONFIG
+
+
+def test_install_ex_unavailable_origin_missing_package(tmp_path: Path) -> None:
+    """`collider install` returns EX_UNAVAILABLE when the origin repo cannot provide the package."""
+    package = _make_package('pkg', '1.0.0', b'payload')
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('pkg', DependencySource.COLLIDER, None)],
+    )
+    Lockfile(
+        dependencies={
+            'pkg': LockedPackage(
+                version='1.0.0',
+                wrap_hash=compute_wrap_hash(package.wrap_text),
+                origin=ORIGIN,
+            ),
+        },
+    ).save(tmp_path / Lockfile.get_filename())
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.origin_url = ORIGIN
+    repo.requires_network.return_value = False
+    repo.get_package.return_value = None  # Origin has no such package.
+    context = _make_context(tmp_path, repo)
+    cmd = Install(argparse.Namespace(offline=False, frozen=False), context)
+
+    assert _run(cmd, tmp_path) == os.EX_UNAVAILABLE
+
+
+def test_install_ex_ioerr_subproject_dir_exists(tmp_path: Path) -> None:
+    """`collider install` returns EX_IOERR when the target subproject directory already exists."""
+    package = _make_package('pkg', '1.0.0', b'payload')
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('pkg', DependencySource.COLLIDER, None)],
+    )
+    Lockfile(
+        dependencies={
+            'pkg': LockedPackage(
+                version='1.0.0',
+                wrap_hash=compute_wrap_hash(package.wrap_text),
+                origin=ORIGIN,
+            ),
+        },
+    ).save(tmp_path / Lockfile.get_filename())
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.origin_url = ORIGIN
+    repo.requires_network.return_value = False
+    repo.get_package.return_value = package
+    context = _make_context(tmp_path, repo)
+
+    # Pre-create the subproject directory so _do_install hits the "already exists" guard.
+    (tmp_path / 'subprojects' / 'pkg').mkdir(parents=True)
+
+    cmd = Install(argparse.Namespace(offline=False, frozen=False), context)
+
+    assert _run(cmd, tmp_path) == os.EX_IOERR
+
+
+def test_install_ex_ok_no_collider_dependencies(tmp_path: Path) -> None:
+    """`collider install` returns EX_OK when collider.json declares no collider dependencies."""
+    _init_project(tmp_path, dependencies=[])  # No lockfile, no collider-source deps.
+
+    context = _make_context(tmp_path, MagicMock(spec=RepositoryInterface))
+    cmd = Install(argparse.Namespace(offline=False, frozen=False), context)
+
+    assert _run(cmd, tmp_path) == os.EX_OK

--- a/test/contract/test_lock_exit_codes.py
+++ b/test/contract/test_lock_exit_codes.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `collider lock` command."""
+
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.file_model.lockfile import Lockfile
+from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+from collider.utils.packaging.PackageType import PackageType
+from collider.utils.packaging.repo_key import make_repo_key
+from test.common.common import Subcommand, run_subcommand
+
+
+ORIGIN = 'https://wrapdb.example.com/v2'
+
+
+def _init_project(tmp_path: Path, dependencies: list[Dependency] | None = None) -> None:
+    """Lay down a minimal meson.build plus collider.json in tmp_path."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n')
+    colliderfile = Colliderfile(dependencies=dependencies or [])
+    colliderfile.save(tmp_path / Colliderfile.get_filename())
+
+
+def test_lock_ex_ok_no_dependencies(tmp_path: Path) -> None:
+    """`collider lock` returns EX_OK and writes an empty lockfile when no deps are declared."""
+    _init_project(tmp_path, dependencies=[])
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert run_subcommand(Subcommand.LOCK, []) == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    lockfile = Lockfile.from_path(tmp_path / Lockfile.get_filename())
+    assert lockfile.dependencies == {}
+    assert lockfile.packages == {}
+
+
+def test_lock_ex_noinput_missing_meson_build(tmp_path: Path) -> None:
+    """`collider lock` returns EX_NOINPUT when no meson.build exists in cwd."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert run_subcommand(Subcommand.LOCK, []) == os.EX_NOINPUT
+    finally:
+        os.chdir(cwd)
+
+
+def test_lock_ex_dataerr_invalid_version_spec(tmp_path: Path) -> None:
+    """`collider lock` returns EX_DATAERR when a declared dependency has an invalid version spec."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, 'not-a-specifier')],
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert run_subcommand(Subcommand.LOCK, []) == os.EX_DATAERR
+    finally:
+        os.chdir(cwd)
+
+
+def test_lock_ex_unavailable_no_matching_package(tmp_path: Path) -> None:
+    """`collider lock` returns EX_UNAVAILABLE when a declared dependency matches no package."""
+    # No repositories configured: build_dep_name_index is empty, so the non-transitive
+    # branch runs and _resolve_newest finds no match for the declared dependency.
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('doesnotexist', DependencySource.COLLIDER, None)],
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert run_subcommand(Subcommand.LOCK, []) == os.EX_UNAVAILABLE
+    finally:
+        os.chdir(cwd)
+
+
+def test_lock_ex_ioerr_fetch_returns_none(tmp_path: Path) -> None:
+    """`collider lock` returns EX_IOERR when a matched package fails to fetch."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, None)],
+    )
+
+    # Repo whose metadata lists the package (search succeeds) but get_package yields None,
+    # so _fetch_package returns None and the non-transitive branch returns EX_IOERR.
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.get_package.return_value = None
+    repo.requires_network.return_value = False
+    repo.origin_url = ORIGIN
+
+    config = MagicMock()
+    config.repositories = {'repo1': repo}
+    config.offline = False
+    context = Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+    repo_key = make_repo_key('shared', '1.0.0', PackageType.WRAP)
+    entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
+    all_matches = {'repo1': {repo_key: entry}}
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with (
+            patch('collider.config.load', return_value=context),
+            patch('collider.subcommand.Install.search_packages', return_value=all_matches),
+        ):
+            assert run_subcommand(Subcommand.LOCK, []) == os.EX_IOERR
+    finally:
+        os.chdir(cwd)

--- a/test/contract/test_patch_exit_codes.py
+++ b/test/contract/test_patch_exit_codes.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider patch command.
+
+One test per documented os.EX_* return path. patch is not dispatchable via
+run_subcommand (no PATCH member in the Subcommand enum), so -- like the existing
+test/subcommand/test_patch.py tests -- these instantiate Patch directly with a
+MagicMock args namespace and patch pathlib.Path.cwd to a controlled directory.
+"""
+
+import json
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.subcommand.Patch import Patch
+
+
+def _write_projectinfo(builddir: Path, name: str = 'demo', version: str = '1.0.0') -> None:
+    info_dir = builddir / 'meson-info'
+    info_dir.mkdir(parents=True, exist_ok=True)
+    (info_dir / 'intro-projectinfo.json').write_text(
+        json.dumps(
+            {
+                'descriptive_name': name,
+                'license': ['MIT'],
+                'license_files': [],
+                'subproject_dir': 'subprojects',
+                'subprojects': [],
+                'version': version,
+            }
+        ),
+        encoding='utf-8',
+    )
+
+
+def _write_mesoninfo(builddir: Path, source_dir: Path) -> None:
+    info_dir = builddir / 'meson-info'
+    info_dir.mkdir(parents=True, exist_ok=True)
+    (info_dir / 'meson-info.json').write_text(
+        json.dumps(
+            {
+                'build_files_updated': False,
+                'directories': {
+                    'build': builddir.as_posix(),
+                    'info': (builddir / 'meson-info').as_posix(),
+                    'source': source_dir.as_posix(),
+                },
+                'error': False,
+                'introspection': {'information': {}, 'version': {}},
+                'meson_version': {'full': '1.10.0', 'major': 1, 'minor': 10, 'patch': 0},
+            }
+        ),
+        encoding='utf-8',
+    )
+
+
+def _init_meson_project(root: Path) -> Path:
+    """Create meson.build and colliderfile in root, marking it a valid project cwd."""
+    (root / 'meson.build').write_text("project('demo', 'c')", encoding='utf-8')
+    Colliderfile(dependencies=[]).save(root / Colliderfile.get_filename())
+    return root
+
+
+def _patch_args(builddir: Path, output: Path | None = None) -> object:
+    return MagicMock(
+        builddir=builddir,
+        base='HEAD',
+        include_uncommitted=True,
+        output=output,
+        list_only=False,
+    )
+
+
+def _mock_run_git_modified(self, args: list, cwd: Path, capture: bool = True):
+    """Mock git so the success path sees one modified, includable file."""
+    if args[:2] == ['rev-parse', '--show-toplevel']:
+        return MagicMock(returncode=0, stdout=str(cwd), stderr='')
+    if args[:2] == ['diff', '--name-status']:
+        return MagicMock(returncode=0, stdout='M\tmodified.txt\n', stderr='')
+    if args[:3] == ['ls-files', '--others', '--exclude-standard']:
+        return MagicMock(returncode=0, stdout='', stderr='')
+    return MagicMock(returncode=1, stdout='', stderr='')
+
+
+def test_patch_ex_ok_archive_written(tmp_path: Path) -> None:
+    """patch returns EX_OK when the patch archive is written to the output path."""
+    source_dir = _init_meson_project(tmp_path)
+    (source_dir / 'modified.txt').write_text('content', encoding='utf-8')
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir)
+    _write_mesoninfo(builddir, source_dir)
+    out_archive = tmp_path / 'out.tar.xz'
+
+    cmd = Patch(_patch_args(builddir=builddir, output=out_archive), MagicMock(spec=Context))
+
+    with (
+        patch('pathlib.Path.cwd', return_value=tmp_path),
+        patch.object(Patch, '_run_git', _mock_run_git_modified),
+    ):
+        result = cmd.execute()
+    assert result == os.EX_OK
+    assert out_archive.exists()
+
+
+def test_patch_ex_noinput_missing_meson_build(tmp_path: Path) -> None:
+    """patch returns EX_NOINPUT when cwd has no meson.build (project validation fails)."""
+    # colliderfile present, meson.build absent: the missing-meson.build guard fires.
+    Colliderfile(dependencies=[]).save(tmp_path / Colliderfile.get_filename())
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir)
+    _write_mesoninfo(builddir, tmp_path)
+
+    cmd = Patch(_patch_args(builddir=builddir), MagicMock(spec=Context))
+
+    with patch('pathlib.Path.cwd', return_value=tmp_path):
+        result = cmd.execute()
+    assert result == os.EX_NOINPUT
+
+
+def test_patch_ex_dataerr_missing_builddir_info(tmp_path: Path) -> None:
+    """patch returns EX_DATAERR when builddir lacks meson-info project metadata."""
+    _init_meson_project(tmp_path)
+    builddir = tmp_path / 'build'
+    # No meson-info under builddir: load_project_metadata returns (None, None, None).
+
+    cmd = Patch(_patch_args(builddir=builddir), MagicMock(spec=Context))
+
+    with patch('pathlib.Path.cwd', return_value=tmp_path):
+        result = cmd.execute()
+    assert result == os.EX_DATAERR
+
+
+def test_patch_ex_ioerr_archive_write_fails(tmp_path: Path) -> None:
+    """patch returns EX_IOERR when writing the patch archive raises OSError."""
+    source_dir = _init_meson_project(tmp_path)
+    (source_dir / 'modified.txt').write_text('content', encoding='utf-8')
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir)
+    _write_mesoninfo(builddir, source_dir)
+    out_archive = tmp_path / 'out.tar.xz'
+
+    cmd = Patch(_patch_args(builddir=builddir, output=out_archive), MagicMock(spec=Context))
+
+    with (
+        patch('pathlib.Path.cwd', return_value=tmp_path),
+        patch.object(Patch, '_run_git', _mock_run_git_modified),
+        patch('collider.subcommand.Patch.tarfile.open', side_effect=OSError('disk full')),
+    ):
+        result = cmd.execute()
+    assert result == os.EX_IOERR

--- a/test/contract/test_pkg_add_exit_codes.py
+++ b/test/contract/test_pkg_add_exit_codes.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `collider pkg add` command.
+
+Each test pins one documented os.EX_* return path of pkg add against its
+exact trigger. See scratchpad exitmap/collider_pkg_add.json for the targets.
+"""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.subcommand.pkg.Add import Add
+from collider.utils.packaging.PackageType import PackageType
+from collider.utils.packaging.repo_key import make_repo_key
+from test.common.common import Subcommand, run_subcommand
+
+
+def _make_context(tmp_path: Path, repos: dict[str, RepositoryInterface]) -> Context:
+    """
+    Build a minimal context backed by a temporary wrap cache.
+    :param tmp_path: Temporary directory for the cache.
+    :param repos: Repository mapping exposed via the config.
+    :return: Context usable for direct Add(args, context) construction.
+    """
+    config = MagicMock()
+    config.repositories = repos
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+
+def _add_args(package: str, *, offline: bool = False) -> argparse.Namespace:
+    """
+    Build the argparse namespace pkg add expects.
+    :param package: Package name to add.
+    :param offline: Whether to run in offline mode.
+    :return: Namespace with all flags Add reads.
+    """
+    return argparse.Namespace(
+        package=package,
+        offline=offline,
+        version=None,
+        include=None,
+        exclude=None,
+        include_conditional=False,
+        exclude_optional=False,
+        force=False,
+    )
+
+
+def test_pkg_add_ex_noinput_no_meson_build(tmp_path: Path) -> None:
+    """pkg add returns EX_NOINPUT when no meson.build exists in the working directory."""
+    os.chdir(tmp_path)
+    assert run_subcommand(Subcommand.PKG, ['add', 'some-package']) == os.EX_NOINPUT
+
+
+def test_pkg_add_ex_dataerr_colliderfile_is_directory(tmp_path: Path) -> None:
+    """pkg add returns EX_DATAERR when collider.json exists on disk as a directory."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    (tmp_path / Colliderfile.get_filename()).mkdir()
+    os.chdir(tmp_path)
+    assert run_subcommand(Subcommand.PKG, ['add', 'foo']) == os.EX_DATAERR
+
+
+def test_pkg_add_ex_ok_existing_transitive_wrap_promoted(tmp_path: Path) -> None:
+    """pkg add returns EX_OK when an installed transitive wrap is promoted to a direct dependency."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir()
+    (subprojects / 'protobuf.wrap').write_text('[wrap-file]\n', encoding='utf-8')
+
+    # A lockfile entry proves the wrap is already required transitively.
+    Lockfile(
+        packages={
+            'protobuf': LockedPackage(
+                version='25.2-4',
+                wrap_hash='sha256:' + '0' * 64,
+                origin='https://wrapdb.example.com/v2/',
+            )
+        }
+    ).save(tmp_path / Lockfile.get_filename())
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    context = _make_context(tmp_path, {'repo1': repo})
+    cmd = Add(_add_args('protobuf'), context)
+
+    os.chdir(tmp_path)
+    assert cmd.execute() == os.EX_OK
+    repo.get_package.assert_not_called()
+    colliderfile = Colliderfile.from_path(tmp_path / Colliderfile.get_filename())
+    assert [dep.name for dep in colliderfile.dependencies] == ['protobuf']
+
+
+def test_pkg_add_ex_unavailable_no_matching_package(tmp_path: Path) -> None:
+    """pkg add returns EX_UNAVAILABLE when no repository yields a matching package."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    repo.requires_network.return_value = False
+    context = _make_context(tmp_path, {'repo1': repo})
+    cmd = Add(_add_args('ghost'), context)
+
+    os.chdir(tmp_path)
+    with patch('collider.subcommand.pkg.Add.search_packages', return_value={}):
+        assert cmd.execute() == os.EX_UNAVAILABLE
+    assert not (tmp_path / Colliderfile.get_filename()).exists()
+
+
+def test_pkg_add_ex_ioerr_offline_missing_cache(tmp_path: Path) -> None:
+    """pkg add returns EX_IOERR when an offline install finds the package uncached."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    repo.requires_network.return_value = True
+    context = _make_context(tmp_path, {'repo1': repo})
+    cmd = Add(_add_args('demo', offline=True), context)
+
+    demo_key = make_repo_key('demo', '1.0.0', PackageType.WRAP)
+    demo_entry = RepoPackageEntry('demo', '1.0.0', PackageType.WRAP)
+
+    os.chdir(tmp_path)
+    with patch(
+        'collider.subcommand.pkg.Add.search_packages',
+        return_value={'repo1': {demo_key: demo_entry}},
+    ):
+        assert cmd.execute() == os.EX_IOERR

--- a/test/contract/test_pkg_info_exit_codes.py
+++ b/test/contract/test_pkg_info_exit_codes.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider ``pkg info`` command."""
+
+import argparse
+import os
+import urllib.parse
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.Wrap import Wrap
+from collider.subcommand.pkg.Info import Info
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+
+
+def _init_project(tmp_path: Path, dependencies: list[Dependency] | None = None) -> None:
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    Colliderfile(dependencies=dependencies or []).save(tmp_path / Colliderfile.get_filename())
+
+
+def _make_context(tmp_path: Path, repositories: dict[str, object]) -> Context:
+    config = MagicMock()
+    config.repositories = repositories
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+
+def test_pkg_info_ex_noinput_unknown_repository(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``pkg info`` returns EX_NOINPUT when a -r repository is absent from config.repositories."""
+    config = MagicMock()
+    config.repositories = {'only_repo': MagicMock()}
+    context = MagicMock(spec=Context)
+    context.config = config
+
+    cmd = Info(
+        argparse.Namespace(package='anypkg', repository=['only_repo', 'missing_repo']), context
+    )
+
+    assert cmd.execute() == os.EX_NOINPUT
+    assert 'Missing' in caplog.text
+
+
+def test_pkg_info_ex_unavailable_no_package_match(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``pkg info`` returns EX_UNAVAILABLE when no resolved repository has the package."""
+    _init_project(tmp_path)
+    wrap_repo = Wrap(urllib.parse.urlparse('https://wrapdb.example.com/v2/'), {})
+    context = _make_context(tmp_path, {'wrapdb': wrap_repo})
+    cmd = Info(argparse.Namespace(package='missing', repository=None), context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch('collider.subcommand.pkg.Info.search_packages', return_value={}):
+            assert cmd.execute() == os.EX_UNAVAILABLE
+    finally:
+        os.chdir(cwd)
+
+    assert 'No package matching query.' in caplog.text
+
+
+def test_pkg_info_ex_ok_reports_package(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """``pkg info`` returns EX_OK on the happy path when a matching package is reported."""
+    _init_project(tmp_path, [Dependency('demo', DependencySource.COLLIDER, '>=1.0')])
+    entry = RepoPackageEntry('demo', '1.0.0')
+    wrap_repo = Wrap(
+        urllib.parse.urlparse('https://wrapdb.example.com/v2/'),
+        {'demo@1.0.0#wrap': entry},
+    )
+    context = _make_context(tmp_path, {'wrapdb': wrap_repo})
+    cmd = Info(argparse.Namespace(package='demo', repository=None), context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch(
+            'collider.subcommand.pkg.Info.search_packages',
+            return_value={'wrapdb': {'demo@1.0.0#wrap': entry}},
+        ):
+            assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert 'Candidate: 1.0.0 (wrapdb)' in caplog.text

--- a/test/contract/test_pkg_prune_exit_codes.py
+++ b/test/contract/test_pkg_prune_exit_codes.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider "pkg prune" command."""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.subcommand.pkg.Prune import Prune
+from test.common.common import Subcommand, run_subcommand
+
+
+ORIGIN = 'https://wrapdb.example.com/v2/'
+
+
+def _init_project(tmp_path: Path) -> None:
+    """Write the minimal meson.build + collider.json so the CWD is a valid project."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    Colliderfile(dependencies=[]).save(tmp_path / Colliderfile.get_filename())
+
+
+def _make_context(tmp_path: Path) -> Context:
+    """Build a minimal context with an empty repository set, as the existing tests do."""
+    config = MagicMock()
+    config.repositories = {}
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+
+def test_pkg_prune_ex_noinput_not_a_project(tmp_path: Path) -> None:
+    """pkg prune returns EX_NOINPUT when the CWD lacks meson.build (not a valid project)."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert run_subcommand(Subcommand.PKG, ['prune']) == os.EX_NOINPUT
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_prune_ex_ok_removes_orphaned_wraps(tmp_path: Path) -> None:
+    """pkg prune returns EX_OK after removing orphaned managed wraps from a valid project."""
+    _init_project(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir()
+    (subprojects / 'abseil-cpp.wrap').write_text('[wrap-file]\n', encoding='utf-8')
+
+    Lockfile(
+        packages={
+            'abseil-cpp': LockedPackage(
+                version='20250814.1-1', wrap_hash='sha256:' + 'b' * 64, origin=ORIGIN
+            ),
+        },
+    ).save(tmp_path / Lockfile.get_filename())
+
+    cmd = Prune(argparse.Namespace(dry_run=False), _make_context(tmp_path))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)

--- a/test/contract/test_pkg_remove_exit_codes.py
+++ b/test/contract/test_pkg_remove_exit_codes.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `collider pkg remove` command."""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.subcommand.pkg.Remove import Remove
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+
+
+def _init_project(tmp_path: Path, dependencies: list[Dependency] | None = None) -> None:
+    """Write a minimal meson.build and collider.json into the project directory."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    colliderfile = Colliderfile(dependencies=dependencies or [])
+    colliderfile.save(tmp_path / Colliderfile.get_filename())
+
+
+def _make_context(tmp_path: Path, repos: dict | None = None) -> Context:
+    """Build a Context with no repositories so transitive resolution stays trivial."""
+    config = MagicMock()
+    config.repositories = repos or {}
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+
+def test_pkg_remove_ex_noinput_no_meson_project(tmp_path: Path) -> None:
+    """pkg remove returns EX_NOINPUT when cwd is not a valid Collider Meson project."""
+    cmd = Remove(argparse.Namespace(package='x', prune=False), _make_context(tmp_path))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_NOINPUT
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_remove_ex_ok_removes_only_declared_dependency(tmp_path: Path) -> None:
+    """pkg remove returns EX_OK when the sole declared Collider dependency is removed."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, None)],
+    )
+
+    cmd = Remove(argparse.Namespace(package='shared', prune=False), _make_context(tmp_path))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    colliderfile = Colliderfile.from_path(tmp_path / Colliderfile.get_filename())
+    assert colliderfile.dependencies == []

--- a/test/contract/test_pkg_search_exit_codes.py
+++ b/test/contract/test_pkg_search_exit_codes.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the ``collider pkg search`` command."""
+
+import os
+
+from pathlib import Path
+
+from collider.cache import WrapCache
+from collider.Package import WrapPackage
+from collider.utils.packaging import compute_file_hash
+from test.common.common import Subcommand, run_subcommand
+
+
+def _populate_cache(tmp_path: Path) -> None:
+    """Store one wrap plus its archive in the isolated on-disk cache.
+    :param tmp_path: Isolated HOME provided by the autouse ``mock_home`` fixture.
+    """
+    cache = WrapCache(tmp_path / '.config' / 'collider' / 'cache')
+
+    content = b'payload'
+    archive = tmp_path / 'demo.tar.xz'
+    archive.write_bytes(content)
+    wrap_text = (
+        '[wrap-file]\n'
+        'source_url=https://example.com/demo.tar.xz\n'
+        'source_filename=demo.tar.xz\n'
+        f'source_hash={compute_file_hash(archive)}\n'
+    )
+    package = WrapPackage.from_wrap_text('demo', '1.0.0', wrap_text)
+    cache.store_wrap(package)
+    cache.archives_dir.mkdir(parents=True, exist_ok=True)
+    (cache.archives_dir / f'{package.source_hash}-demo.tar.xz').write_bytes(content)
+
+
+def test_pkg_search_ex_ok_cache_hit(tmp_path: Path):
+    """`pkg search --cache` returns EX_OK when a cached wrap matches the pattern."""
+    _populate_cache(tmp_path)
+    assert run_subcommand(Subcommand.PKG, ['search', '--cache', 'demo']) == os.EX_OK
+
+
+def test_pkg_search_ex_unavailable_cache_empty():
+    """`pkg search --cache` returns EX_UNAVAILABLE when no cached wrap matches."""
+    assert run_subcommand(Subcommand.PKG, ['search', '--cache', 'nomatch']) == os.EX_UNAVAILABLE
+
+
+def test_pkg_search_ex_noinput_unknown_repository():
+    """`pkg search -r <name>` returns EX_NOINPUT when the repository is unknown."""
+    assert run_subcommand(Subcommand.PKG, ['search', '-r', 'nonexistent', '.*']) == os.EX_NOINPUT

--- a/test/contract/test_pkg_upgrade_exit_codes.py
+++ b/test/contract/test_pkg_upgrade_exit_codes.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider ``pkg upgrade`` command."""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from collider.cache import WrapCache
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.subcommand.pkg.Upgrade import Upgrade
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+from collider.utils.packaging.PackageType import PackageType
+from collider.utils.packaging.repo_key import make_repo_key
+
+
+def _init_project(tmp_path: Path, dependencies: list[Dependency] | None = None) -> None:
+    """Write a minimal meson.build and collider.json into the project directory."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    Colliderfile(dependencies=dependencies or []).save(tmp_path / Colliderfile.get_filename())
+
+
+def _make_context(tmp_path: Path, repo: RepositoryInterface | None = None) -> Context:
+    """Build a Context whose only repository is the supplied mock, if any."""
+    config = MagicMock()
+    config.repositories = {'repo1': repo} if repo is not None else {}
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+
+
+def test_pkg_upgrade_ex_ok_no_declared_dependencies(tmp_path: Path) -> None:
+    """``pkg upgrade`` returns EX_OK when no Collider-managed dependencies are declared."""
+    _init_project(tmp_path, [])
+    cmd = Upgrade(
+        argparse.Namespace(package=None, version=None, offline=False), _make_context(tmp_path)
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_upgrade_ex_usage_version_without_package(tmp_path: Path) -> None:
+    """``pkg upgrade`` returns EX_USAGE when --version is given without a package name."""
+    _init_project(tmp_path, [Dependency('shared', DependencySource.COLLIDER, None)])
+    cmd = Upgrade(
+        argparse.Namespace(package=None, version='<2.0.0', offline=False),
+        _make_context(tmp_path),
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_USAGE
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_upgrade_ex_dataerr_invalid_declared_constraint(tmp_path: Path) -> None:
+    """``pkg upgrade`` returns EX_DATAERR when the declared version constraint is unparseable."""
+    _init_project(tmp_path, [Dependency('shared', DependencySource.COLLIDER, '@@bad@@')])
+    cmd = Upgrade(
+        argparse.Namespace(package='shared', version=None, offline=False),
+        _make_context(tmp_path),
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_DATAERR
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_upgrade_ex_noinput_no_meson_project(tmp_path: Path) -> None:
+    """``pkg upgrade`` returns EX_NOINPUT when cwd is not a valid Collider Meson project."""
+    cmd = Upgrade(
+        argparse.Namespace(package=None, version=None, offline=False), _make_context(tmp_path)
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_NOINPUT
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_upgrade_ex_unavailable_no_package_match(tmp_path: Path) -> None:
+    """``pkg upgrade`` returns EX_UNAVAILABLE when the search finds no matching package."""
+    _init_project(tmp_path, [Dependency('shared', DependencySource.COLLIDER, None)])
+    repo = MagicMock(spec=RepositoryInterface)
+    cmd = Upgrade(
+        argparse.Namespace(package='shared', version=None, offline=False),
+        _make_context(tmp_path, repo),
+    )
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch('collider.subcommand.pkg.Upgrade.search_packages', return_value={}):
+            assert cmd.execute() == os.EX_UNAVAILABLE
+    finally:
+        os.chdir(cwd)
+
+
+def test_pkg_upgrade_ex_ioerr_offline_missing_cache(tmp_path: Path) -> None:
+    """``pkg upgrade`` returns EX_IOERR when an offline upgrade's wrap is absent from the cache."""
+    _init_project(tmp_path, [Dependency('shared', DependencySource.COLLIDER, None)])
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.requires_network.return_value = True
+    cmd = Upgrade(
+        argparse.Namespace(package='shared', version=None, offline=True),
+        _make_context(tmp_path, repo),
+    )
+
+    repo_key = make_repo_key('shared', '2.0.0', PackageType.WRAP)
+    entry = RepoPackageEntry('shared', '2.0.0', PackageType.WRAP)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch(
+            'collider.subcommand.pkg.Upgrade.search_packages',
+            return_value={'repo1': {repo_key: entry}},
+        ):
+            assert cmd.execute() == os.EX_IOERR
+    finally:
+        os.chdir(cwd)

--- a/test/contract/test_publish_exit_codes.py
+++ b/test/contract/test_publish_exit_codes.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider "publish" command.
+
+One test per documented os.EX_* return path of :meth:`Publish.execute`. Each test
+drives the EXACT documented trigger and asserts the os.EX_* constant, mirroring
+the fixtures and mocking seams used in test/subcommand/test_push.py.
+"""
+
+import argparse
+import json
+import os
+import socket
+import urllib.parse
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from collider.Context import Context
+from collider.repository.implementation.Collider import Collider
+from collider.repository.implementation.Filesystem import Filesystem
+from collider.repository.implementation.Wrap import Wrap
+from collider.subcommand.Publish import Publish
+
+
+def _write_projectinfo(builddir: Path, name: str = 'demo', version: str = '1.0.0') -> None:
+    info_dir = builddir / 'meson-info'
+    info_dir.mkdir(parents=True, exist_ok=True)
+    (info_dir / 'intro-projectinfo.json').write_text(
+        json.dumps(
+            {
+                'descriptive_name': name,
+                'license': ['MIT'],
+                'license_files': [],
+                'subproject_dir': 'subprojects',
+                'subprojects': [],
+                'version': version,
+            }
+        ),
+        encoding='utf-8',
+    )
+
+
+def _write_mesoninfo(builddir: Path, source_dir: Path) -> None:
+    info_dir = builddir / 'meson-info'
+    info_dir.mkdir(parents=True, exist_ok=True)
+    (info_dir / 'meson-info.json').write_text(
+        json.dumps(
+            {
+                'directories': {
+                    'build': builddir.as_posix(),
+                    'info': info_dir.as_posix(),
+                    'source': source_dir.as_posix(),
+                },
+            }
+        ),
+        encoding='utf-8',
+    )
+
+
+def _push_args(
+    repository: str,
+    builddir: Path,
+    patch_archive: Path | None = None,
+    push_token_env: str = 'COLLIDER_PUSH_TOKEN',
+    dry_run: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        repository=repository,
+        builddir=builddir,
+        patch_archive=patch_archive,
+        push_token_env=push_token_env,
+        dry_run=dry_run,
+    )
+
+
+def _unused_localhost_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('127.0.0.1', 0))
+        return sock.getsockname()[1]
+
+
+def _mock_context(repositories: dict[str, object]) -> MagicMock:
+    config = MagicMock()
+    config.repositories = repositories
+    context = MagicMock(spec=Context)
+    context.config = config
+    return context
+
+
+def test_publish_ex_noinput_missing_patch_archive(tmp_path: Path) -> None:
+    """publish returns EX_NOINPUT when --patch-archive points to a non-existent path."""
+    args = _push_args(
+        repository='local',
+        builddir=tmp_path / 'build',
+        patch_archive=tmp_path / 'missing.patch',
+    )
+    cmd = Publish(args, _mock_context({}))
+    assert cmd.execute() == os.EX_NOINPUT
+
+
+def test_publish_ex_dataerr_patch_archive_is_directory(tmp_path: Path) -> None:
+    """publish returns EX_DATAERR when --patch-archive exists but is not a regular file."""
+    patch_dir = tmp_path / 'archive_dir'
+    patch_dir.mkdir()
+    args = _push_args(
+        repository='local',
+        builddir=tmp_path / 'build',
+        patch_archive=patch_dir,
+    )
+    cmd = Publish(args, _mock_context({}))
+    assert cmd.execute() == os.EX_DATAERR
+
+
+def test_publish_ex_usage_repo_not_publishable(tmp_path: Path) -> None:
+    """publish returns EX_USAGE when the resolved repo is neither Filesystem nor Collider."""
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    wrap_repo = Wrap(urllib.parse.urlparse('https://packages.example.com/v2/'), {})
+    cmd = Publish(
+        _push_args(repository='remote', builddir=builddir), _mock_context({'remote': wrap_repo})
+    )
+    assert cmd.execute() == os.EX_USAGE
+
+
+def test_publish_ex_cantcreat_duplicate_version(tmp_path: Path) -> None:
+    """publish returns EX_CANTCREAT when the same name/version already exists in the repo."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    (source_dir / 'meson.build').write_text("project('demo', 'c')", encoding='utf-8')
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    context = _mock_context({'local': repo})
+    args = _push_args(repository='local', builddir=builddir)
+    assert Publish(args, context).execute() == os.EX_OK
+    assert Publish(args, context).execute() == os.EX_CANTCREAT
+
+
+def test_publish_ex_ioerr_unreachable_endpoint(tmp_path: Path) -> None:
+    """publish returns EX_IOERR when the collider push endpoint is unreachable (URLError)."""
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    closed_port = _unused_localhost_port()
+    collider_repo = Collider(urllib.parse.urlparse(f'http://127.0.0.1:{closed_port}/v2/'), {})
+    cmd = Publish(
+        _push_args(repository='remote', builddir=builddir), _mock_context({'remote': collider_repo})
+    )
+
+    os.environ['COLLIDER_PUSH_TOKEN'] = 'secret'
+    try:
+        assert cmd.execute() == os.EX_IOERR
+    finally:
+        del os.environ['COLLIDER_PUSH_TOKEN']
+
+
+def test_publish_ex_ok_filesystem_success(tmp_path: Path) -> None:
+    """publish returns EX_OK after building the archive and writing to a filesystem repo."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url='https://packages.example.com/collider/')
+
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    (source_dir / 'meson.build').write_text("project('demo', 'c')", encoding='utf-8')
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    cmd = Publish(_push_args(repository='local', builddir=builddir), _mock_context({'local': repo}))
+    assert cmd.execute() == os.EX_OK

--- a/test/contract/test_repo_exit_codes.py
+++ b/test/contract/test_repo_exit_codes.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `repo` command."""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from collider.Context import Context
+from collider.file_model.configfile import ConfigFile
+from collider.subcommand.Repo import Repo
+
+
+def _make_context() -> Context:
+    return MagicMock(spec=Context)
+
+
+def _repo_args(
+    *,
+    name: str = '',
+    repo_type: str = '',
+    url: str = '',
+    publish_url: str | None = None,
+    action: str = 'add',
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo_subcommand=action,
+        repo_action=action,
+        name=name,
+        type=repo_type,
+        url=url,
+        publish_url=publish_url,
+    )
+
+
+def test_repo_ex_usage_unknown_subcommand() -> None:
+    """`repo` returns EX_USAGE when repo_action is not add/remove/list."""
+    # Not reachable via run_subcommand: subparsers are required=True, so argparse
+    # exits 2 before execute() runs. Must drive execute() directly.
+    cmd = Repo(_repo_args(action='bogus'), _make_context())
+
+    assert cmd.execute() == os.EX_USAGE
+
+
+def test_repo_ex_dataerr_duplicate_name() -> None:
+    """`repo add` returns EX_DATAERR when the repository name already exists."""
+    first = Repo(
+        _repo_args(name='wrapdb', repo_type='wrap', url='https://wrapdb.mesonbuild.com/v2/'),
+        _make_context(),
+    )
+    second = Repo(
+        _repo_args(name='wrapdb', repo_type='wrap', url='https://other.example.com/v2/'),
+        _make_context(),
+    )
+
+    assert first.execute() == os.EX_OK
+    assert second.execute() == os.EX_DATAERR
+
+
+def test_repo_ex_ioerr_save_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`repo add` returns EX_IOERR when saving the config to disk raises OSError."""
+    # Seed an existing config first so _load_or_create_config does not save (and
+    # fail) before the targeted config_file.save() in _execute_add.
+    seed = Repo(
+        _repo_args(name='wrapdb', repo_type='wrap', url='https://wrapdb.mesonbuild.com/v2/'),
+        _make_context(),
+    )
+    assert seed.execute() == os.EX_OK
+
+    def _raise(self: ConfigFile, path: Path) -> None:
+        raise OSError('disk full')
+
+    monkeypatch.setattr(ConfigFile, 'save', _raise)
+
+    cmd = Repo(
+        _repo_args(name='mirror', repo_type='wrap', url='https://mirror.example.com/v2/'),
+        _make_context(),
+    )
+
+    assert cmd.execute() == os.EX_IOERR
+
+
+def test_repo_ex_ok_add_succeeds() -> None:
+    """`repo add` returns EX_OK when the repository is added and config saved."""
+    cmd = Repo(
+        _repo_args(name='wrapdb', repo_type='wrap', url='https://wrapdb.mesonbuild.com/v2/'),
+        _make_context(),
+    )
+
+    assert cmd.execute() == os.EX_OK
+
+
+def test_repo_ex_noinput_remove_nonexistent() -> None:
+    """`repo remove` returns EX_NOINPUT when no entry matches the requested name."""
+    cmd = Repo(_repo_args(name='nonexistent', action='remove'), _make_context())
+
+    assert cmd.execute() == os.EX_NOINPUT

--- a/test/contract/test_serve_exit_codes.py
+++ b/test/contract/test_serve_exit_codes.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider "serve" command."""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from collider.Context import Context
+from collider.subcommand.Serve import Serve
+
+
+def _make_context() -> Context:
+    return MagicMock(spec=Context)
+
+
+def _serve_args(
+    path: Path | str = 'repo',
+    host: str = '127.0.0.1',
+    port: int = 8000,
+    push_token: str | None = None,
+    push_token_env: str = 'COLLIDER_PUSH_TOKEN',
+    publish_url: str | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        path=Path(path),
+        host=host,
+        port=port,
+        push_token=push_token,
+        push_token_env=push_token_env,
+        publish_url=publish_url,
+    )
+
+
+def test_serve_ex_usage_non_directory_repo_path(tmp_path: Path) -> None:
+    """serve returns EX_USAGE when the repository path exists but is not a directory."""
+    repo_path = tmp_path / 'repo-file'
+    repo_path.write_text('not a repo', encoding='utf-8')
+    cmd = Serve(_serve_args(path=repo_path), _make_context())
+
+    assert cmd.execute() == os.EX_USAGE
+
+
+def test_serve_ex_ioerr_new_repo_endpoint_validation_fails(tmp_path: Path) -> None:
+    """serve returns EX_IOERR when a newly created repo fails endpoint validation."""
+    repo_path = tmp_path / 'repo'  # Does not pre-exist, so repo_was_created is True.
+    cmd = Serve(_serve_args(path=repo_path), _make_context())
+
+    with patch.object(
+        Serve,
+        '_validate_new_repo_endpoints',
+        side_effect=RuntimeError('validation smoke test failed'),
+    ):
+        assert cmd.execute() == os.EX_IOERR
+
+
+def test_serve_ex_ok_starts_and_stops(tmp_path: Path) -> None:
+    """serve returns EX_OK when the server starts and serve_forever exits cleanly."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    cmd = Serve(_serve_args(path=repo_path), _make_context())
+
+    server = MagicMock()
+    server.serve_forever.side_effect = KeyboardInterrupt
+
+    with patch('collider.subcommand.Serve.ThreadingHTTPServer', return_value=server):
+        assert cmd.execute() == os.EX_OK
+
+    server.server_close.assert_called_once()

--- a/test/contract/test_setup_exit_codes.py
+++ b/test/contract/test_setup_exit_codes.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `collider setup` command."""
+
+import os
+import subprocess
+
+from pathlib import Path
+
+import pytest
+
+from collider.utils import meson
+from test.common.common import Subcommand, run_subcommand
+
+
+def test_setup_ex_ok_valid_project(meson_project: Path, tmp_path: Path) -> None:
+    """`collider setup` returns EX_OK when meson setup and collider validation succeed."""
+    result = run_subcommand(
+        Subcommand.SETUP,
+        ['--sourcedir', str(meson_project), '--builddir', str(tmp_path)],
+    )
+    # The 'shared' fixture needs system libmd; skip when it is absent.
+    if meson_project.name == 'shared' and result != os.EX_OK:
+        pytest.skip('shared project requires system libmd')
+    assert result == os.EX_OK
+
+
+def test_setup_ex_dataerr_missing_sourcedir(tmp_path: Path) -> None:
+    """`collider setup` returns EX_DATAERR when the source directory does not exist."""
+    missing_sourcedir = tmp_path / 'missing_sourcedir'
+    assert not missing_sourcedir.exists()
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(missing_sourcedir), '--builddir', str(tmp_path)],
+        )
+        == os.EX_DATAERR
+    )
+
+
+def test_setup_ex_software_meson_setup_fails(tmp_path: Path, monkeypatch) -> None:
+    """`collider setup` returns EX_SOFTWARE when meson setup exits non-zero."""
+    sourcedir = tmp_path / 'srcdir'
+    sourcedir.mkdir()
+    (sourcedir / 'collider.json').write_text('{}')
+    (sourcedir / 'meson.build').touch()
+
+    def _raise_called_process_error(*args, **kwargs) -> None:
+        raise subprocess.CalledProcessError(1, ['meson', 'setup'])
+
+    # Pass validation so the EX_SOFTWARE comes solely from the setup failure,
+    # not from a missing meson binary or an unbuildable meson.build.
+    monkeypatch.setattr(meson, 'validate', lambda: None)
+    monkeypatch.setattr(meson, 'setup', _raise_called_process_error)
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(tmp_path / 'build')],
+        )
+        == os.EX_SOFTWARE
+    )
+
+
+def test_setup_ex_unavailable_meson_missing(tmp_path: Path, monkeypatch) -> None:
+    """`collider setup` returns EX_UNAVAILABLE when Meson is missing or too old."""
+
+    def _raise_unavailable() -> None:
+        raise meson.MesonUnavailableError('Could not locate "meson" executable.')
+
+    monkeypatch.setattr(meson, 'validate', _raise_unavailable)
+
+    assert (
+        run_subcommand(Subcommand.SETUP, ['--builddir', str(tmp_path / 'build')])
+        == os.EX_UNAVAILABLE
+    )

--- a/test/contract/test_status_exit_codes.py
+++ b/test/contract/test_status_exit_codes.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the collider `status` command."""
+
+import argparse
+import os
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from collider.Context import Context
+from collider.file_model.colliderfile import Colliderfile
+from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.subcommand.Status import Status
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+
+
+ORIGIN = 'https://wrapdb.example.com/v2/'
+
+
+def test_status_ex_ok_normal_completion(tmp_path: Path) -> None:
+    """`status` returns EX_OK on a normal run over a valid project with a lockfile."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n')
+    Colliderfile(
+        dependencies=[Dependency('alpha', DependencySource.COLLIDER, '1.0.0')],
+    ).save(tmp_path / Colliderfile.get_filename())
+
+    # A lockfile makes resolution unnecessary, so no network/meson is needed.
+    Lockfile(
+        dependencies={
+            'alpha': LockedPackage(version='1.0.0', wrap_hash='sha256:' + 'a' * 64, origin=ORIGIN)
+        },
+    ).save(tmp_path / Lockfile.get_filename())
+
+    cmd = Status(argparse.Namespace(), MagicMock(spec=Context))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+
+def test_status_ex_noinput_missing_meson_build(tmp_path: Path, caplog) -> None:
+    """`status` returns EX_NOINPUT when no meson.build exists in the current directory."""
+    # Empty cwd: the first _validate_cwd() guard (missing meson.build) fires.
+    cmd = Status(argparse.Namespace(), MagicMock(spec=Context))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_NOINPUT
+    finally:
+        os.chdir(cwd)
+
+    assert 'No meson.build file found in current directory.' in caplog.text

--- a/test/contract/test_unpublish_exit_codes.py
+++ b/test/contract/test_unpublish_exit_codes.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Exit-code contract tests for the `unpublish` command."""
+
+import argparse
+import io
+import os
+import urllib.error
+import urllib.parse
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from collider.Context import Context
+from collider.Package import WrapPackage
+from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.Collider import Collider
+from collider.repository.implementation.Filesystem import Filesystem
+from collider.repository.implementation.Wrap import Wrap
+from collider.subcommand.Unpublish import Unpublish
+from collider.utils.packaging.PackageType import PackageType
+from collider.utils.packaging.repo_key import make_repo_key
+from test.common.common import Subcommand, run_subcommand
+
+
+def _wrap_text() -> str:
+    return (
+        '[wrap-file]\n'
+        'source_url=https://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        'source_hash=deadbeef\n'
+        '\n'
+        '[provide]\n'
+        'foo = foo_dep\n'
+    )
+
+
+def _args(repository: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        repository=repository,
+        package='foo',
+        version='1.0.0',
+        push_token_env='COLLIDER_PUSH_TOKEN',
+    )
+
+
+def _context(repositories: dict) -> Context:
+    config = MagicMock()
+    config.repositories = repositories
+    context = MagicMock(spec=Context)
+    context.config = config
+    return context
+
+
+def test_unpublish_ex_noinput_repository_not_in_config() -> None:
+    """`unpublish` returns EX_NOINPUT when the named repository is absent from config."""
+    # Deterministic via run_subcommand: a bootstrapped empty config has no such repo.
+    exit_code = run_subcommand(
+        Subcommand.UNPUBLISH,
+        ['nonexistent-repo', 'some-package', '1.0.0'],
+    )
+
+    assert exit_code == os.EX_NOINPUT
+
+
+def test_unpublish_ex_usage_wrap_repository() -> None:
+    """`unpublish` returns EX_USAGE when the resolved repository is a read-only wrap repo."""
+    packages = {
+        make_repo_key('foo', '1.0.0', PackageType.WRAP): RepoPackageEntry(
+            'foo', '1.0.0', PackageType.WRAP
+        ),
+    }
+    repo = Wrap(urllib.parse.urlparse('https://wrapdb.example/v2/'), packages)
+    cmd = Unpublish(_args('wrapdb'), _context({'wrapdb': repo}))
+
+    assert cmd.execute() == os.EX_USAGE
+
+
+def test_unpublish_ex_ioerr_get_package_failure(tmp_path: Path) -> None:
+    """`unpublish` returns EX_IOERR when loading the package from a filesystem repo raises OSError."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url=repo_path.as_uri())
+    repo.add_package(WrapPackage.from_wrap_text('foo', '1.0.0', _wrap_text()))
+    cmd = Unpublish(_args('local'), _context({'local': repo}))
+
+    with patch.object(repo, 'get_package', side_effect=OSError('Read failed.')):
+        assert cmd.execute() == os.EX_IOERR
+
+
+def test_unpublish_ex_ok_filesystem_removal(tmp_path: Path) -> None:
+    """`unpublish` returns EX_OK when the package is loaded and removed from a filesystem repo."""
+    repo_path = tmp_path / 'repo'
+    repo_path.mkdir()
+    repo = Filesystem(repo_path, publish_url=repo_path.as_uri())
+    repo.add_package(WrapPackage.from_wrap_text('foo', '1.0.0', _wrap_text()))
+
+    repo_key = make_repo_key('foo', '1.0.0', PackageType.WRAP)
+    wrap_path = repo_path / 'foo_1.0.0' / 'foo.wrap'
+    assert repo_key in repo.packages
+    assert wrap_path.exists()
+
+    cmd = Unpublish(_args('local'), _context({'local': repo}))
+
+    assert cmd.execute() == os.EX_OK
+    assert repo_key not in repo.packages
+    assert not wrap_path.exists()
+
+
+@pytest.mark.parametrize('status_code', [401, 403])
+def test_unpublish_ex_noperm_collider_auth_error(status_code: int) -> None:
+    """`unpublish` returns EX_NOPERM when a collider remote answers with HTTP 401 or 403."""
+    repo = Collider(urllib.parse.urlparse('https://packages.example.com/v2/'), {})
+    cmd = Unpublish(_args('remote'), _context({'remote': repo}))
+
+    with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
+        with patch('collider.subcommand.Unpublish.safe_urlopen') as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.HTTPError(
+                'https://packages.example.com/v2/_collider/v1/packages/foo/1.0.0',
+                status_code,
+                'Auth error.',
+                {},
+                io.BytesIO(b'{"error": "Auth failed."}'),
+            )
+            assert cmd.execute() == os.EX_NOPERM


### PR DESCRIPTION
## Summary

Pins collider's `os.EX_*` exit-code contract (documented in
`docs/reference/cli.md`) so a refactor cannot silently change a command's exit
code without a test failing.

- New suite under `test/contract/`, one file per command, **67 tests** across
  17 commands: one test per distinct exit code on a representative trigger.
- Built from a code-level map of all 137 return paths, then every test was
  adversarially verified to trigger the **intended** branch (not a different
  path returning the same code) and to run green. A completeness critic confirmed
  no target code is left untested.

### Scope
Covered: every distinct `EX_*` code each command can return. Intentionally not
covered (not a per-command contract): the wrapper-level uncaught-exception
(`exit 1`) and argparse usage (`exit 2`) codes, and two constructor-time paths
raised before `execute()`.

### Discovered inconsistency (Closes #38 notes it; not fixed here)
`collider init` returns `EX_DATAERR` (65) for a missing `meson.build`, while
`check`, `status`, and `lock` return `EX_NOINPUT` (66) for the same condition.
The tests pin current behavior; aligning `init` to 66 is a separate decision.

## Verification
- `test/contract/`: 70 passed (67 functions plus parametrization).
- Full suite: 680 passed, 91.11% coverage.
- ruff format/check, ty, pylint (10.00/10) all clean.

Closes #38
