### PR TITLE
fix: return EX_NOINPUT for missing project inputs in init and setup

### DIFF
--- a/collider/subcommand/Init.py
+++ b/collider/subcommand/Init.py
@@ -78,7 +78,7 @@ class Init(SubcommandInterface):
         meson_path = project_root / 'meson.build'
         if not meson_path.exists():
             logger.critical('No meson.build file found in current directory.')
-            return os.EX_DATAERR
+            return os.EX_NOINPUT
 
         self._hint_missing_license(meson_path)
 

--- a/collider/subcommand/Setup.py
+++ b/collider/subcommand/Setup.py
@@ -99,21 +99,21 @@ Examples:
 
         if not self.sourcedir.exists():
             logger.critical(f'Source directory "{self.sourcedir.absolute()}" does not exist')
-            return os.EX_DATAERR
+            return os.EX_NOINPUT
 
         if not (self.sourcedir / 'meson.build').exists():
             logger.critical(
                 f'No "meson.build" file found in "{self.sourcedir.absolute()}" '
                 '- not a valid Meson project'
             )
-            return os.EX_DATAERR
+            return os.EX_NOINPUT
 
         if not (self.sourcedir / Colliderfile.get_filename()).exists():
             logger.critical(
                 f'No "{Colliderfile.get_filename()}" file found in "{self.sourcedir.absolute()}" '
                 '- not a valid Collider project.'
             )
-            return os.EX_DATAERR
+            return os.EX_NOINPUT
 
         try:
             meson.setup(

--- a/test/contract/test_init_exit_codes.py
+++ b/test/contract/test_init_exit_codes.py
@@ -32,13 +32,12 @@ def test_init_ex_ok_meson_build_present(tmp_path: Path) -> None:
     assert (tmp_path / Colliderfile.get_filename()).exists()
 
 
-def test_init_ex_dataerr_missing_meson_build(tmp_path: Path) -> None:
-    """`collider init` returns EX_DATAERR when no meson.build exists in cwd (current behavior)."""
-    # Current behavior: missing meson.build returns EX_DATAERR (65), not EX_NOINPUT.
+def test_init_ex_noinput_missing_meson_build(tmp_path: Path) -> None:
+    """`collider init` returns EX_NOINPUT when no meson.build exists in cwd."""
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert run_subcommand(Subcommand.INIT, []) == os.EX_DATAERR
+        assert run_subcommand(Subcommand.INIT, []) == os.EX_NOINPUT
     finally:
         os.chdir(cwd)
 

--- a/test/contract/test_setup_exit_codes.py
+++ b/test/contract/test_setup_exit_codes.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from collider.subcommand.Setup import Setup
 from collider.utils import meson
 from test.common.common import Subcommand, run_subcommand
 
@@ -26,14 +27,36 @@ def test_setup_ex_ok_valid_project(meson_project: Path, tmp_path: Path) -> None:
     assert result == os.EX_OK
 
 
-def test_setup_ex_dataerr_missing_sourcedir(tmp_path: Path) -> None:
-    """`collider setup` returns EX_DATAERR when the source directory does not exist."""
+def test_setup_ex_noinput_missing_sourcedir(tmp_path: Path) -> None:
+    """`collider setup` returns EX_NOINPUT when the source directory does not exist."""
     missing_sourcedir = tmp_path / 'missing_sourcedir'
     assert not missing_sourcedir.exists()
     assert (
         run_subcommand(
             Subcommand.SETUP,
             ['--sourcedir', str(missing_sourcedir), '--builddir', str(tmp_path)],
+        )
+        == os.EX_NOINPUT
+    )
+
+
+def test_setup_ex_dataerr_validation_fails(tmp_path: Path, monkeypatch) -> None:
+    """`collider setup` returns EX_DATAERR when post-setup validation fails."""
+    sourcedir = tmp_path / 'srcdir'
+    sourcedir.mkdir()
+    (sourcedir / 'collider.json').write_text('{}')
+    (sourcedir / 'meson.build').touch()
+
+    # Pass validation and setup so the EX_DATAERR comes solely from _validate
+    # returning False, which is the "data present but invalid" contract for setup.
+    monkeypatch.setattr(meson, 'validate', lambda: None)
+    monkeypatch.setattr(meson, 'setup', lambda *args, **kwargs: None)
+    monkeypatch.setattr(Setup, '_validate', lambda self: False)
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(tmp_path / 'build')],
         )
         == os.EX_DATAERR
     )

--- a/test/subcommand/test_init.py
+++ b/test/subcommand/test_init.py
@@ -66,7 +66,7 @@ def test_init_requires_meson_build(tmp_path: Path) -> None:
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert run_subcommand(Subcommand.INIT, []) == os.EX_DATAERR
+        assert run_subcommand(Subcommand.INIT, []) == os.EX_NOINPUT
     finally:
         os.chdir(cwd)
 

--- a/test/subcommand/test_setup.py
+++ b/test/subcommand/test_setup.py
@@ -68,7 +68,7 @@ def test_execute_missing_sourcedir(tmp_path: Path, capfd: pytest.CaptureFixture)
             Subcommand.SETUP,
             ['--sourcedir', str(missing_sourcedir), '--builddir', str(tmp_path)],
         )
-        == os.EX_DATAERR
+        == os.EX_NOINPUT
     )
 
     stdout, stderr = capfd.readouterr()
@@ -86,7 +86,7 @@ def test_execute_missing_mesonbuild(tmp_path: Path, capfd: pytest.CaptureFixture
             Subcommand.SETUP,
             ['--sourcedir', str(empty_sourcedir), '--builddir', str(tmp_path)],
         )
-        == os.EX_DATAERR
+        == os.EX_NOINPUT
     )
 
     stdout, stderr = capfd.readouterr()


### PR DESCRIPTION
## Summary

`init` and `setup` returned `EX_DATAERR` (65) for a **missing** project input
(meson.build, collider.json, or source directory), while `check`, `status`,
`lock`, and `patch` return `EX_NOINPUT` (66) for the same condition. Per
`sysexits.h`, a missing input file is `EX_NOINPUT`; `EX_DATAERR` is for data that
exists but is invalid. This aligns the two outliers with the rest of the CLI and
with the documented exit-code legend (`docs/reference/cli.md` already maps 66 to
"no meson.build, collider.json, or lockfile", so no doc change is needed).

Surfaced by the exit-code contract suite (#38).

## Changes
- `init`: missing meson.build 65 -> 66.
- `setup`: missing sourcedir / meson.build / collider.json 65 -> 66.
- Unchanged (genuine data errors keep 65): `init` collider.json-is-a-directory,
  `setup` post-setup validation failure.
- Updated 3 unit tests + 2 contract tests; added a deterministic contract test
  pinning `setup`'s `EX_DATAERR` validation-failure path.

## Out of scope (flagged separately)
`init` returns `EX_DATAERR` when `collider.json` exists but is a directory. That
path exists (it is not a missing input), so it is left as-is; whether it should
become `EX_CANTCREAT` (73) is a separate semantic decision.

## Verification
- Full suite: 681 passed, 91.11% coverage; ruff/ty/pylint clean.
- Developed in adversarial pair review: the plan and the final diff were each
  challenged by an independent reviewer (caught 3 breaking unit tests and
  confirmed the new validation test isolates the intended path).
