### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "collider-wraps"
-version = "1.2.0"
+version = "1.3.0"
 description = "A package and dependency manager for Meson projects."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "collider-wraps"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
Version bump for the 1.3.0 release. Tag will be pushed after merge to trigger the PyPI publish workflow. uv.lock synced.