### PR TITLE
fix(progress): hide tqdm bars in non-interactive output (#47)

### DIFF
--- a/collider/log.py
+++ b/collider/log.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 from enum import Enum
-from typing import Callable, cast
+from typing import Callable, Optional, cast
 
 
 first_include = False
@@ -88,6 +88,22 @@ def init_logger(level: Level) -> None:
 def configure_logging(verbose: bool) -> None:
     """Switch between concise and debug logging based on CLI flags."""
     init_logger(Level.DEBUG if verbose else Level.INFO)
+
+
+def progress_disable() -> Optional[bool]:
+    """Return the value to pass to tqdm's ``disable=`` argument.
+
+    ``True`` force-hides animated progress bars when debug logging is on (the
+    bars would interleave with verbose logs) or when running under CI. ``None``
+    lets tqdm auto-detect: bars are shown on an interactive TTY and hidden when
+    output is piped or redirected, so non-interactive logs stay clean and
+    grep-able instead of filling with carriage-return spam.
+    """
+    if logger.level <= logging.DEBUG:
+        return True
+    if os.environ.get('CI'):
+        return True
+    return None
 
 
 if not first_include:

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -4,7 +4,6 @@
 """Add a package dependency to the project."""
 
 import argparse
-import logging
 import os
 import re
 import shutil
@@ -22,7 +21,7 @@ from tqdm import tqdm
 from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile, compute_wrap_hash
-from collider.log import logger
+from collider.log import logger, progress_disable
 from collider.Package import WrapPackage
 from collider.repository import search_packages
 from collider.repository.entries import RepoPackageEntry
@@ -509,7 +508,7 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
             desc='Installing dependencies',
             unit='pkg',
             leave=False,
-            disable=not transitive_candidates or logger.level <= logging.DEBUG,
+            disable=not transitive_candidates or progress_disable(),
         )
         for pkg_name, candidate in progress:
             progress.set_postfix_str(pkg_name)

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import re
 import subprocess
 import tarfile
@@ -25,7 +24,7 @@ from packaging.version import InvalidVersion
 from tqdm import tqdm
 
 from collider.cache import WrapCache
-from collider.log import logger
+from collider.log import logger, progress_disable
 from collider.repository import search_packages
 from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson.scan import (
@@ -529,7 +528,7 @@ class ResolutionResult:
 class _ProgressReporter(resolvelib.BaseReporter):
     """Reporter that displays a tqdm progress bar during resolution."""
 
-    def __init__(self, *, disable: bool = False):
+    def __init__(self, *, disable: Optional[bool] = None):
         self._disable = disable
         self._bar: Optional[tqdm] = None
 
@@ -589,7 +588,7 @@ def resolve_dependencies(
         include_names=include_names,
         exclude_names=exclude_names,
     )
-    reporter = _ProgressReporter(disable=logger.level <= logging.DEBUG)
+    reporter = _ProgressReporter(disable=progress_disable())
     resolver = resolvelib.Resolver(provider, reporter)
 
     root_req = Requirement(root_name, root_version_spec)
@@ -655,7 +654,7 @@ def resolve_all_dependencies(
         exclude_optional=exclude_optional,
         root_overrides=root_overrides,
     )
-    reporter = _ProgressReporter(disable=logger.level <= logging.DEBUG)
+    reporter = _ProgressReporter(disable=progress_disable())
     resolver = resolvelib.Resolver(provider, reporter)
 
     root_reqs = [Requirement(r.name, r.version_spec) for r in roots]

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 MOG Robotics OÜ.
+
+from collider.log import Level, init_logger, progress_disable
+
+
+def test_progress_disable_true_when_debug(monkeypatch):
+    """Debug logging force-hides bars so they don't interleave with verbose logs."""
+    monkeypatch.delenv('CI', raising=False)
+    init_logger(Level.DEBUG)
+    try:
+        assert progress_disable() is True
+    finally:
+        init_logger(Level.INFO)
+
+
+def test_progress_disable_true_under_ci(monkeypatch):
+    """A CI environment is non-interactive, so bars are force-hidden."""
+    monkeypatch.setenv('CI', 'true')
+    init_logger(Level.INFO)
+    assert progress_disable() is True
+
+
+def test_progress_disable_none_when_interactive(monkeypatch):
+    """Otherwise defer to tqdm: None auto-detects the TTY at the output stream."""
+    monkeypatch.delenv('CI', raising=False)
+    init_logger(Level.INFO)
+    assert progress_disable() is None


### PR DESCRIPTION
## Summary
Fixes #47. tqdm progress bars were disabled based on log level only (`logger.level <= logging.DEBUG`), never on whether output is interactive — so they were still emitted to non-TTY output (pipes, redirects, CI), cluttering captured logs with repeated carriage-return partial lines.

## Approach
Added a small shared helper `collider.log.progress_disable()` and used it at all three tqdm call sites (the two `resolve_*` paths in `resolver.py` and the install loop in `pkg/Add.py`), replacing the duplicated `logger.level <= logging.DEBUG` condition.

It returns the value passed to tqdm's `disable=`:
- `True` — force-hide when debug logging is on (bars would interleave with verbose logs) **or** when running under CI (`$CI`).
- `None` — otherwise defer to tqdm's own auto-detect, which hides the bar when its output stream is not a TTY.

Using `disable=None` rather than a hand-rolled `sys.stdout.isatty()` check is deliberate: tqdm writes to **stderr** by default, and `disable=None` checks `isatty()` on the *actual* output stream, so it stays correct regardless of which stream the bar uses.

Note: I intentionally did **not** gate bars on `NO_COLOR` — that's a color directive, not a "no progress" one; the non-TTY auto-detect already covers the piped/redirected case it's usually conflated with. Happy to add it if you'd prefer.

## Tests
Added `test/test_log.py` covering the three branches (debug → `True`, CI → `True`, interactive → `None`).

## Notes
- No runtime behavior change for interactive terminals — bars still show as before.
- `import logging` was removed from `resolver.py` and `pkg/Add.py` as it became unused.