### PR TITLE
feat(setup): force wrap fallback so builds use locked versions (#44)

### DIFF
--- a/collider/subcommand/Setup.py
+++ b/collider/subcommand/Setup.py
@@ -22,6 +22,11 @@ from collider.utils.compat import override
 from collider.utils.meson.info import InfoFile, get_project_info, validate_projectinfo
 from collider.utils.meson.infoTypes import ProjectInfo
 from collider.utils.packaging import validate_dependencies
+from collider.utils.project_state import (
+    collect_force_fallback_names,
+    managed_package_names,
+    scan_wraps,
+)
 
 
 class Setup(SubcommandInterface):
@@ -116,10 +121,16 @@ Examples:
             return os.EX_NOINPUT
 
         try:
+            fallback_args = self._force_fallback_args()
+        except ValueError as exc:
+            logger.critical(str(exc))
+            return os.EX_DATAERR
+
+        try:
             meson.setup(
                 sourcedir=self.sourcedir,
                 builddir=self.builddir,
-                args=self.meson_setup_args,
+                args=fallback_args + self.meson_setup_args,
             )
         except subprocess.CalledProcessError as e:
             logger.critical('meson setup failed: %s', e)
@@ -132,6 +143,68 @@ Examples:
             return os.EX_DATAERR
 
         return os.EX_OK
+
+    @staticmethod
+    def _user_forces_fallback(meson_args: list[str]) -> bool:
+        """
+        Detect a user-supplied force-fallback option in either Meson spelling.
+        Meson rejects setting `force_fallback_for` via both `--force-fallback-for` and
+        `-Dforce_fallback_for`, so collider must spot either form and defer rather than
+        inject a second one that aborts the build.
+        :param meson_args: Meson arguments passed after `--`.
+        """
+        names = ('--force-fallback-for', '-Dforce_fallback_for')
+        return any(
+            arg == name or arg.startswith(name + '=') for arg in meson_args for name in names
+        )
+
+    def _force_fallback_args(self) -> list[str]:
+        """
+        Force Meson to use collider's wraps so the build matches locked versions.
+        Scope comes from collider.lock when present (direct + transitive, authoritative);
+        without a lock, every present wrap is forced as a best effort and the user is warned
+        that transitive deps may not be scoped correctly. Meson keeps only the last
+        `--force-fallback-for`, so a user-supplied one is deferred to rather than overridden
+        with a flag Meson would discard alongside a misleading message.
+        :return: A single `--force-fallback-for` argument, or an empty list.
+        :raises ValueError: When collider.lock exists but is malformed.
+        """
+        managed = managed_package_names(self.sourcedir)
+
+        if self._user_forces_fallback(self.meson_setup_args):
+            logger.warning(
+                'A "--force-fallback-for" argument was supplied; collider will not force '
+                'its managed wraps, so locked versions may be shadowed by system copies.'
+            )
+            return []
+
+        subprojects_dir = self.sourcedir / meson.SUBPROJECTS_DIR
+        forced = collect_force_fallback_names(subprojects_dir, managed)
+
+        # Surface wraps a present lock does not cover, so an empty/stale lock under-scoping
+        # the build is visible rather than a silent reproducibility hole.
+        if managed is not None:
+            excluded = sorted(set(scan_wraps(subprojects_dir)) - managed)
+            if excluded:
+                logger.info(
+                    f'{len(excluded)} wrap(s) in "subprojects/" are not in collider.lock and are '
+                    f"left to Meson's default resolution: {', '.join(excluded)}. "
+                    'Run "collider lock" if collider should manage them.'
+                )
+
+        if not forced:
+            return []
+        if managed is None:
+            logger.warning(
+                'No collider.lock found: forcing all wraps in "subprojects/" as a best effort. '
+                'Transitive dependencies may not be scoped correctly; '
+                'run "collider lock" for authoritative, reproducible resolution.'
+            )
+        logger.info(
+            f'Forcing wrap fallback for {len(forced)} managed dependency name(s) '
+            'so locked wraps are used instead of system copies.'
+        )
+        return [f'--force-fallback-for={",".join(forced)}']
 
     def _cleanup_builddir(self, builddir_preexisted: bool) -> None:
         """Remove only build directories created by this run."""

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import configparser
 import shutil
 
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Optional
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile
 from collider.log import logger
+from collider.Package import get_provide_names
 from collider.utils.meson import SUBPROJECTS_DIR
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 
@@ -82,6 +84,78 @@ def scan_wraps(subprojects_dir: Path) -> list[str]:
     if not subprojects_dir.exists():
         return []
     return [p.stem for p in subprojects_dir.glob('*.wrap') if p.is_file()]
+
+
+def managed_package_names(sourcedir: Path) -> Optional[set[str]]:
+    """
+    Return collider's authoritative managed package set, or None when it is unknown.
+    The lockfile is the only record of transitive installs, so a present collider.lock
+    yields the precise set (direct + transitive) plus the colliderfile's direct entries.
+    None signals the caller to fall back to wrap presence, since before a lock exists a
+    transitive wrap is recorded nowhere but the wrap file itself.
+    :param sourcedir: Project source directory.
+    :return: Managed package names, or None when collider.lock is absent.
+    :raises ValueError: When collider.lock exists but cannot be parsed.
+    """
+    lock_path = sourcedir / Lockfile.get_filename()
+    if not lock_path.exists():
+        return None
+
+    try:
+        lockfile = Lockfile.from_path(lock_path)
+    except Exception as exc:
+        raise ValueError(f'collider.lock is malformed: {exc}') from exc
+
+    names = set(lockfile.all_packages)
+
+    # Cover direct deps added since the last lock; the lockfile owns transitive ones.
+    colliderfile_path = sourcedir / Colliderfile.get_filename()
+    if colliderfile_path.exists():
+        try:
+            colliderfile = Colliderfile.from_path(colliderfile_path)
+        except Exception as exc:
+            # The lockfile is authoritative; a broken colliderfile is caught later by setup
+            # validation. Scope to lock-only names here rather than abort.
+            logger.debug(f'Ignoring unreadable collider.json for force-fallback scoping: {exc}')
+            return names
+        names |= {
+            dep.name for dep in colliderfile.dependencies if dep.source == DependencySource.COLLIDER
+        }
+    return names
+
+
+def collect_force_fallback_names(
+    subprojects_dir: Path, managed: Optional[set[str]] = None
+) -> list[str]:
+    """
+    Collect the names to force to wrap fallback at `meson setup`.
+    Each in-scope wrap contributes its stem (the subproject name) and any names it declares
+    in [provide], so Meson uses collider's wraps instead of system copies and the build
+    matches the locked versions. Both forms independently force the fallback, and reading
+    [provide] keeps the catch2/catch2-with-main dependency-name vs package-name mismatch
+    correct. When ``managed`` is given, only wraps for those collider-managed packages are
+    forced; when it is None (no lockfile yet), every present wrap is forced as a best effort.
+    :param subprojects_dir: Path to the subprojects directory.
+    :param managed: Collider-managed package names to restrict forcing to, or None.
+    :return: Sorted, de-duplicated names for `meson setup --force-fallback-for`.
+    """
+    if not subprojects_dir.exists():
+        return []
+
+    names: set[str] = set()
+    for wrap_path in subprojects_dir.glob('*.wrap'):
+        if not wrap_path.is_file():
+            continue
+        if managed is not None and wrap_path.stem not in managed:
+            continue
+        names.add(wrap_path.stem)
+        try:
+            names.update(get_provide_names(wrap_path.read_text(encoding='utf-8')))
+        except (ValueError, OSError, configparser.Error):
+            # Redirect/git or malformed wraps lack a parseable [wrap-file]; the stem alone
+            # still forces the subproject.
+            continue
+    return sorted(names)
 
 
 def warn_if_lockfile_needs_refresh(package_name: str) -> None:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,8 +81,11 @@ collider pkg add zlib --version '>=1.2,<2.0'
 collider setup
 ```
 
-This runs Meson setup with the collider-managed subprojects in place. Pass
-extra Meson arguments after `--`:
+This runs Meson setup with the collider-managed subprojects in place, forcing
+Meson to use Collider's wraps instead of system copies. Until you create
+`collider.lock` in the next step, it forces all wraps and prints a warning;
+`collider lock` then makes the scope authoritative. Pass extra Meson arguments
+after `--`:
 
 ```bash
 collider setup -- --buildtype=debug

--- a/docs/guide/locking-and-installing.md
+++ b/docs/guide/locking-and-installing.md
@@ -116,6 +116,11 @@ Commands like `pkg add`, `pkg remove`, and `pkg upgrade` modify
 `collider.json` and the installed state but never touch `collider.lock`.
 The lockfile is only written by `collider lock`.
 
+The lockfile also scopes which wraps `collider setup` forces Meson to use: with
+a lockfile, only its managed packages (direct and transitive) are forced;
+without one, `setup` forces every present wrap as a best effort and warns. See
+[Wrap Fallback Enforcement](project-setup.md#wrap-fallback-enforcement).
+
 Per-dependency `include`, `exclude`, `include_conditional`, and
 `exclude_optional` in `collider.json` control transitive resolution:
 `include` and `exclude` are scoped to each root; `include_conditional` and

--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -82,6 +82,44 @@ You can also specify a different source directory:
 collider setup --sourcedir path/to/project
 ```
 
+### Wrap Fallback Enforcement
+
+By default Meson prefers a system or `pkg-config` dependency over a subproject
+wrap, so a Collider-managed dependency can be silently shadowed by a different
+system version. To keep the build consistent with what Collider manages,
+`collider setup` passes Meson `--force-fallback-for` for Collider's wraps, so
+Meson uses the wrap (matching the locked version when a lockfile is present)
+instead of a system copy.
+
+What gets forced depends on whether a lockfile exists:
+
+- **With `collider.lock`**: only managed packages are forced: the lockfile's
+  direct and transitive entries plus the `"source": "collider"` dependencies
+  from `collider.json`. A wrap present in `subprojects/` but absent from the
+  lock (for example one you added by hand) is left to Meson's default
+  resolution, and `setup` reports it.
+- **Without a lockfile**: every wrap in `subprojects/` is forced as a best
+  effort, and `setup` warns that transitive dependencies may not be scoped
+  precisely. Run `collider lock` for authoritative scoping.
+
+A malformed `collider.lock` makes `setup` fail with `EX_DATAERR` before Meson
+runs.
+
+This is the reproducibility trade-off: a forced wrap that does not compile on
+your toolchain fails the build, where a system copy might have built. To take
+control of exactly which subprojects are forced, pass your own
+`--force-fallback-for` (or `-Dforce_fallback_for`); Collider then defers to it
+and forces nothing on its own, since Meson keeps only the last value:
+
+```bash
+collider setup -- --force-fallback-for=fmt,spdlog
+```
+
+Your list **replaces** Collider's; it is not merged. Any managed wrap you omit
+returns to Meson's default resolution, where a system copy can shadow the locked
+version, so list every subproject you want pinned. To let Meson resolve
+everything normally, pass an empty list (`--force-fallback-for=`).
+
 ## Build Directory Conventions
 
 Collider defaults to `collider-build` as the build directory to avoid conflicts

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,6 +60,14 @@ collider setup --builddir build
 collider setup -- --buildtype=debug
 ```
 
+`collider setup` forces Meson to use Collider's wraps for managed dependencies
+(via `--force-fallback-for`) so the build matches the locked versions rather
+than system copies. The forced set is scoped to `collider.lock` when present, or
+all wraps in `subprojects/` (with a warning) when it is absent; a malformed
+`collider.lock` aborts with `EX_DATAERR`. A user-supplied `--force-fallback-for`
+or `-Dforce_fallback_for` is honored as-is. See
+[Wrap Fallback Enforcement](../guide/project-setup.md#wrap-fallback-enforcement).
+
 ---
 
 ## `lock`

--- a/test/subcommand/test_setup.py
+++ b/test/subcommand/test_setup.py
@@ -3,15 +3,56 @@
 
 """Test the setup subcommand."""
 
+import argparse
+import logging
 import os
 import re
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
+from collider.Context import Context
+from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.subcommand.Setup import Setup
 from collider.utils import meson
 from test.common.common import Subcommand, run_subcommand
+
+
+def _force_fallback_args(sourcedir: Path, meson_args: list[str] | None = None) -> list[str]:
+    """Drive Setup._force_fallback_args in isolation, without invoking Meson."""
+    args = argparse.Namespace(
+        sourcedir=sourcedir,
+        builddir=Path('build'),
+        meson_setup_args=(['--', *meson_args] if meson_args else []),
+    )
+    return Setup(args, MagicMock(spec=Context))._force_fallback_args()
+
+
+def _write_wrapped_foo_project(sourcedir: Path) -> None:
+    """Create a project whose `dependency('foo')` is backed by a present local wrap."""
+    subprojects = sourcedir / 'subprojects'
+    subprojects.mkdir(parents=True)
+    (sourcedir / 'collider.json').write_text('{}')
+    (sourcedir / 'meson.build').write_text(
+        "project('p', 'c', version: '1.0.0', license: 'MIT')\nfoo_dep = dependency('foo')\n"
+    )
+    # The subproject directory already exists, so Meson resolves 'foo' locally (no download).
+    (subprojects / 'foo.wrap').write_text(
+        '[wrap-file]\n'
+        'directory = foo\n'
+        'source_url = https://example.invalid/foo.tar.gz\n'
+        'source_filename = foo.tar.gz\n'
+        f'source_hash = {"0" * 64}\n'
+        '\n[provide]\n'
+        'foo = foo_dep\n'
+    )
+    foo_dir = subprojects / 'foo'
+    foo_dir.mkdir()
+    (foo_dir / 'meson.build').write_text(
+        "project('foo', 'c', version: '1.2.3')\nfoo_dep = declare_dependency()\n"
+    )
 
 
 def test_setup_meson_unavailable_returns_ex_unavailable(tmp_path: Path, monkeypatch) -> None:
@@ -175,6 +216,231 @@ def test_preexisting_builddir_not_removed_on_failure(tmp_path: Path):
     )
     assert builddir.exists()
     assert sentinel.exists()
+
+
+def test_setup_forces_fallback_for_present_wraps(tmp_path: Path, capfd: pytest.CaptureFixture):
+    """Without a lock, collider forces all present wraps and warns about scoping."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(tmp_path / 'build')],
+            verbose=True,
+        )
+        == os.EX_OK
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert '--force-fallback-for=foo' in stderr
+    assert 'No collider.lock found' in stderr
+    # The lock-scoped exclusion notice must not fire when there is no lock.
+    assert 'not in collider.lock' not in stderr
+
+
+def test_setup_with_lock_scopes_force_to_managed_packages(
+    tmp_path: Path, capfd: pytest.CaptureFixture
+):
+    """With a lock, only managed packages are forced; an unmanaged wrap is left alone."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    # bar is an unmanaged wrap (not in the lock); it must not be forced.
+    (sourcedir / 'subprojects' / 'bar.wrap').write_text(
+        '[wrap-file]\ndirectory = bar\nsource_url = https://example.invalid/bar.tar.gz\n'
+        f'source_filename = bar.tar.gz\nsource_hash = {"0" * 64}\n\n[provide]\nbar = bar_dep\n'
+    )
+    Lockfile(
+        dependencies={
+            'foo': LockedPackage(
+                version='1.2.3', wrap_hash='sha256:' + '0' * 64, origin='https://wrapdb.example/v2/'
+            )
+        },
+    ).save(sourcedir / Lockfile.get_filename())
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(tmp_path / 'build')],
+            verbose=True,
+        )
+        == os.EX_OK
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert '--force-fallback-for=foo' in stderr
+    assert '--force-fallback-for=bar' not in stderr
+    assert 'foo,bar' not in stderr and 'bar,foo' not in stderr
+    assert 'No collider.lock found' not in stderr
+    # The unmanaged wrap is surfaced, not silently dropped.
+    assert 'not in collider.lock' in stderr and 'bar' in stderr
+
+
+def test_setup_empty_lock_surfaces_unscoped_wraps(tmp_path: Path, capfd: pytest.CaptureFixture):
+    """An empty/stale lock that omits a present wrap reports it instead of silently dropping it."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    Lockfile().save(sourcedir / Lockfile.get_filename())
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(tmp_path / 'build')],
+            verbose=True,
+        )
+        == os.EX_OK
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert '--force-fallback-for' not in stderr  # nothing forced under an empty lock
+    assert 'not in collider.lock' in stderr and 'foo' in stderr
+
+
+def test_setup_malformed_lock_errors(tmp_path: Path, capfd: pytest.CaptureFixture):
+    """A malformed collider.lock aborts setup before Meson runs."""
+    sourcedir = tmp_path / 'project'
+    sourcedir.mkdir()
+    (sourcedir / 'collider.json').write_text('{}')
+    (sourcedir / 'meson.build').write_text("project('p', 'c', version: '1.0.0', license: 'MIT')\n")
+    (sourcedir / 'collider.lock').write_text('{ not valid json', encoding='utf-8')
+
+    builddir = tmp_path / 'build'
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(builddir)],
+        )
+        == os.EX_DATAERR
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert 'collider.lock is malformed' in stderr
+    assert not builddir.exists()
+
+
+def test_setup_defers_to_user_supplied_force_fallback(tmp_path: Path, capfd: pytest.CaptureFixture):
+    """A user --force-fallback-for takes over: collider must not inject its own (Meson last-wins)."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            [
+                '--sourcedir',
+                str(sourcedir),
+                '--builddir',
+                str(tmp_path / 'build'),
+                '--',
+                '--force-fallback-for=bar',
+            ],
+            verbose=True,
+        )
+        == os.EX_OK
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert '--force-fallback-for=bar' in stderr
+    assert '--force-fallback-for=foo' not in stderr
+    assert 'collider will not force' in stderr
+
+
+def test_setup_no_wraps_injects_no_fallback_flag(
+    tmp_path: Path, meson_project: Path, capfd: pytest.CaptureFixture
+):
+    """Without any wraps, collider must not inject a --force-fallback-for flag."""
+    if meson_project.name == 'shared':
+        pytest.skip('shared project requires system libmd')
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(meson_project), '--builddir', str(tmp_path / 'build')],
+            verbose=True,
+        )
+        == os.EX_OK
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert '--force-fallback-for' not in stderr
+
+
+def test_force_args_no_lock_forces_all_and_warns(tmp_path: Path, caplog) -> None:
+    """No lock: force every present wrap and warn about imprecise scoping."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    with caplog.at_level(logging.INFO, logger='collider'):
+        assert _force_fallback_args(sourcedir) == ['--force-fallback-for=foo']
+    assert 'No collider.lock found' in caplog.text
+
+
+def test_force_args_scopes_to_lock(tmp_path: Path, caplog) -> None:
+    """With a lock, force only managed wraps and report the unmanaged one."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    (sourcedir / 'subprojects' / 'bar.wrap').write_text('[wrap-file]\ndirectory = bar\n')
+    Lockfile(
+        dependencies={
+            'foo': LockedPackage(version='1', wrap_hash='sha256:' + '0' * 64, origin='https://x/')
+        }
+    ).save(sourcedir / Lockfile.get_filename())
+    with caplog.at_level(logging.INFO, logger='collider'):
+        assert _force_fallback_args(sourcedir) == ['--force-fallback-for=foo']
+    assert 'No collider.lock found' not in caplog.text
+    assert 'not in collider.lock' in caplog.text and 'bar' in caplog.text
+
+
+def test_force_args_empty_lock_forces_nothing_but_reports(tmp_path: Path, caplog) -> None:
+    """An empty lock forces nothing yet still surfaces the present, unscoped wrap."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    Lockfile().save(sourcedir / Lockfile.get_filename())
+    with caplog.at_level(logging.INFO, logger='collider'):
+        assert _force_fallback_args(sourcedir) == []
+    assert 'not in collider.lock' in caplog.text and 'foo' in caplog.text
+
+
+def test_force_args_malformed_lock_raises(tmp_path: Path) -> None:
+    """A malformed lock raises before any Meson interaction."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    (sourcedir / 'collider.lock').write_text('{ not json', encoding='utf-8')
+    with pytest.raises(ValueError, match='malformed'):
+        _force_fallback_args(sourcedir)
+
+
+def test_force_args_malformed_lock_wins_over_user_override(tmp_path: Path) -> None:
+    """A malformed lock aborts even when the user supplies their own --force-fallback-for."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    (sourcedir / 'collider.lock').write_text('garbage', encoding='utf-8')
+    with pytest.raises(ValueError, match='malformed'):
+        _force_fallback_args(sourcedir, ['--force-fallback-for=x'])
+
+
+def test_force_args_defers_to_user_dashdash_spelling(tmp_path: Path, caplog) -> None:
+    """A user --force-fallback-for makes collider defer."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    with caplog.at_level(logging.WARNING, logger='collider'):
+        assert _force_fallback_args(sourcedir, ['--force-fallback-for=x']) == []
+    assert 'collider will not force' in caplog.text
+
+
+def test_force_args_defers_to_user_dash_d_spelling(tmp_path: Path, caplog) -> None:
+    """A user -Dforce_fallback_for must also be detected (Meson rejects both spellings at once)."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    with caplog.at_level(logging.WARNING, logger='collider'):
+        assert _force_fallback_args(sourcedir, ['-Dforce_fallback_for=x']) == []
+    assert 'collider will not force' in caplog.text
+
+
+def test_force_args_no_wraps_returns_empty(tmp_path: Path) -> None:
+    """A project with no wraps yields no force argument."""
+    sourcedir = tmp_path / 'project'
+    sourcedir.mkdir()
+    assert _force_fallback_args(sourcedir) == []
 
 
 def test_validate_failure_invalid_version(tmp_path: Path, capfd: pytest.CaptureFixture):

--- a/test/utils/test_project_state.py
+++ b/test/utils/test_project_state.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 MOG Robotics OÜ.
+
+"""Tests for project-state helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from collider.file_model.colliderfile import Colliderfile
+from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.utils.packaging.Dependency import Dependency, DependencySource
+from collider.utils.project_state import collect_force_fallback_names, managed_package_names
+
+
+_ORIGIN = 'https://wrapdb.example.com/v2/'
+_HASH = 'sha256:' + 'a' * 64
+
+
+_WRAP_FILE = """\
+[wrap-file]
+directory = {directory}
+source_url = https://example.invalid/{directory}.tar.gz
+source_filename = {directory}.tar.gz
+source_hash = {hash}
+"""
+
+
+def _wrap_file_text(directory: str, provides: dict[str, str] | None = None) -> str:
+    """Build well-formed [wrap-file] text, optionally with a [provide] section."""
+    text = _WRAP_FILE.format(directory=directory, hash='0' * 64)
+    if provides:
+        text += '\n[provide]\n' + ''.join(f'{name} = {var}\n' for name, var in provides.items())
+    return text
+
+
+def _write_wrap(subprojects: Path, stem: str, text: str) -> None:
+    """Write a wrap file into a subprojects directory, creating it if needed."""
+    subprojects.mkdir(parents=True, exist_ok=True)
+    (subprojects / f'{stem}.wrap').write_text(text, encoding='utf-8')
+
+
+def test_collect_returns_stem_and_provide_keys(tmp_path: Path) -> None:
+    """A wrap contributes both its stem and every name in its [provide] section."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(
+        subprojects,
+        'catch2',
+        _wrap_file_text(
+            'Catch2-3.4.0',
+            {'catch2': 'catch2_dep', 'catch2-with-main': 'catch2_with_main_dep'},
+        ),
+    )
+    assert collect_force_fallback_names(subprojects) == ['catch2', 'catch2-with-main']
+
+
+def test_collect_unions_multiple_wraps(tmp_path: Path) -> None:
+    """Names from every present wrap are merged and sorted."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'fmt', _wrap_file_text('fmt-11', {'fmt': 'fmt_dep'}))
+    _write_wrap(subprojects, 'spdlog', _wrap_file_text('spdlog-1.14', {'spdlog': 'spdlog_dep'}))
+    assert collect_force_fallback_names(subprojects) == ['fmt', 'spdlog']
+
+
+def test_collect_wrap_without_provide_uses_stem(tmp_path: Path) -> None:
+    """A wrap with no [provide] section still forces its subproject by stem."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'zlib', _wrap_file_text('zlib-1.3'))
+    assert collect_force_fallback_names(subprojects) == ['zlib']
+
+
+def test_collect_non_wrap_file_uses_stem_only(tmp_path: Path) -> None:
+    """Redirect/git wraps lack [wrap-file]; the stem alone forces the subproject."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(
+        subprojects,
+        'mydep',
+        '[wrap-git]\nurl = https://example.invalid/mydep.git\nrevision = head\n',
+    )
+    assert collect_force_fallback_names(subprojects) == ['mydep']
+
+
+def test_collect_malformed_ini_wrap_uses_stem_only(tmp_path: Path) -> None:
+    """A wrap that is not parseable INI (no section header) is tolerated; the stem forces it."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'broken', 'not an ini file, no section header\n')
+    assert collect_force_fallback_names(subprojects) == ['broken']
+
+
+def test_collect_missing_directory_returns_empty(tmp_path: Path) -> None:
+    """A non-existent subprojects directory yields no names."""
+    assert collect_force_fallback_names(tmp_path / 'nope') == []
+
+
+def test_collect_empty_subprojects_returns_empty(tmp_path: Path) -> None:
+    """A subprojects directory with no wraps yields no names."""
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir()
+    assert collect_force_fallback_names(subprojects) == []
+
+
+def test_collect_restricts_to_managed_packages(tmp_path: Path) -> None:
+    """When a managed set is given, an unmanaged (e.g. hand-placed) wrap is left alone."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'fmt', _wrap_file_text('fmt-11', {'fmt': 'fmt_dep'}))
+    _write_wrap(subprojects, 'bar', _wrap_file_text('bar-1', {'bar': 'bar_dep'}))
+    assert collect_force_fallback_names(subprojects, {'fmt'}) == ['fmt']
+
+
+def test_collect_empty_managed_set_forces_nothing(tmp_path: Path) -> None:
+    """An empty managed set forces nothing, even with wraps present."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'fmt', _wrap_file_text('fmt-11', {'fmt': 'fmt_dep'}))
+    assert collect_force_fallback_names(subprojects, set()) == []
+
+
+def test_managed_names_returns_none_without_lock(tmp_path: Path) -> None:
+    """No lockfile means the managed set is unknown, signalling a wrap-presence fallback."""
+    assert managed_package_names(tmp_path) is None
+
+
+def test_managed_names_unions_lock_and_colliderfile(tmp_path: Path) -> None:
+    """The managed set merges lock direct + transitive packages with colliderfile direct deps."""
+    Lockfile(
+        dependencies={'foo': LockedPackage(version='1.0', wrap_hash=_HASH, origin=_ORIGIN)},
+        packages={'fmt': LockedPackage(version='11.0', wrap_hash=_HASH, origin=_ORIGIN)},
+    ).save(tmp_path / Lockfile.get_filename())
+    Colliderfile(dependencies=[Dependency('baz', DependencySource.COLLIDER, '1.0')]).save(
+        tmp_path / Colliderfile.get_filename()
+    )
+    assert managed_package_names(tmp_path) == {'foo', 'fmt', 'baz'}
+
+
+def test_managed_names_raises_on_malformed_lock(tmp_path: Path) -> None:
+    """A malformed lockfile is a hard error, not a silent fallback."""
+    (tmp_path / Lockfile.get_filename()).write_text('{ not valid json', encoding='utf-8')
+    with pytest.raises(ValueError):
+        managed_package_names(tmp_path)
+
+
+def test_managed_names_tolerates_malformed_colliderfile(tmp_path: Path) -> None:
+    """A valid lock with a corrupt colliderfile yields the lock-only managed set."""
+    Lockfile(
+        dependencies={'foo': LockedPackage(version='1.0', wrap_hash=_HASH, origin=_ORIGIN)},
+    ).save(tmp_path / Lockfile.get_filename())
+    (tmp_path / Colliderfile.get_filename()).write_text('{ not valid json', encoding='utf-8')
+    assert managed_package_names(tmp_path) == {'foo'}


### PR DESCRIPTION
Closes #44.

## Problem
Meson's default `--wrap-mode=default` prefers system/pkg-config dependencies over subproject wraps. A collider-locked package (e.g. `nlohmann_json 3.12.0-1`) could therefore be silently shadowed by a different system version (`3.11.3`) at build time, while `collider status` still printed `[ok]` (the wrap hash matched, but the build never used the wrap).

## Fix (enforcement, not detection)
`collider setup` now injects `--force-fallback-for=<names>` so Meson uses collider's wraps and the build matches the locked versions. The name list is the union, over every present `subprojects/*.wrap`, of:
- the wrap **stem** (forces the whole subproject), and
- its **`[provide]` keys** (forces each provided dependency name).

Both forms independently force the fallback, and reading `[provide]` keeps the `catch2` / `catch2-with-main` dependency-name vs package-name mapping correct.

Fixing the *cause* makes `status [ok]` (wrap-hash match) honest, so this **deliberately avoids** a fragile version-string comparison (the lock stores wrapdb-revision form `3.12.0-1`; Meson reports upstream `3.12.0`). `status` is intentionally left unchanged: its wrap-hash drift report is the only signal for hand-edited wraps and for builds configured via plain `meson setup`.

## User override
Meson keeps only the last `--force-fallback-for`. If the user supplies their own, collider **defers to it and warns** rather than emit a flag Meson would discard alongside a misleading "forcing" message. Passing `--force-fallback-for` is thus the escape hatch for anyone who wants a system copy.

## Behavior change (intentional)
Forcing the wrap converts "system dep works, wrap avoided" into "the pinned wrap is used or the build fails". A wrap that does not compile on the local toolchain will now fail where a system copy might have worked. That is the reproducibility contract; collider logs an INFO line when it forces, so it is never silent. (Backward compatibility intentionally not preserved, per AGENTS.md.)

## Tests
- `test/utils/test_project_state.py`: 6 unit tests for the name-collection helper (stem + provide keys, multi-wrap union, no `[provide]`, non-`[wrap-file]` redirect/git, missing/empty dir).
- `test/subcommand/test_setup.py`: 3 behavioral tests (injects the flag and Meson configures; defers to a user-supplied flag; injects nothing when no wraps exist).
- Full suite: 691 passed, 1 skipped, 91.3% coverage. `ruff`, `ty`, and `act` (lint + pytest) all green.

## Not in scope
The version-mismatch *warning* and docs items from #44 are not included; enforcement closes the core reproducibility gap. Happy to follow up on docs (the two Meson gotchas: a user `--force-fallback-for` replaces the list; `--wrap-mode=nofallback` does not undo forcing).