### PR TITLE
Disable progress bars outside interactive output

### DIFF
--- a/collider/log.py
+++ b/collider/log.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 from enum import Enum
-from typing import Callable, cast
+from typing import Callable, TextIO, cast
 
 
 first_include = False
@@ -88,6 +88,14 @@ def init_logger(level: Level) -> None:
 def configure_logging(verbose: bool) -> None:
     """Switch between concise and debug logging based on CLI flags."""
     init_logger(Level.DEBUG if verbose else Level.INFO)
+
+
+def should_disable_progress(*, stream: TextIO | None = None) -> bool:
+    """Return whether animated progress output should be suppressed."""
+    ci_value = os.environ.get('CI', '').strip().lower()
+    ci_enabled = ci_value not in ('', '0', 'false', 'no', 'off')
+    output = stream if stream is not None else sys.stdout
+    return logger.level <= Level.DEBUG.value or ci_enabled or not output.isatty()
 
 
 if not first_include:

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -4,7 +4,6 @@
 """Add a package dependency to the project."""
 
 import argparse
-import logging
 import os
 import re
 import shutil
@@ -22,7 +21,7 @@ from tqdm import tqdm
 from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile, compute_wrap_hash
-from collider.log import logger
+from collider.log import logger, should_disable_progress
 from collider.Package import WrapPackage
 from collider.repository import search_packages
 from collider.repository.entries import RepoPackageEntry
@@ -509,7 +508,7 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
             desc='Installing dependencies',
             unit='pkg',
             leave=False,
-            disable=not transitive_candidates or logger.level <= logging.DEBUG,
+            disable=not transitive_candidates or should_disable_progress(),
         )
         for pkg_name, candidate in progress:
             progress.set_postfix_str(pkg_name)

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import re
 import subprocess
 import tarfile
@@ -25,7 +24,7 @@ from packaging.version import InvalidVersion
 from tqdm import tqdm
 
 from collider.cache import WrapCache
-from collider.log import logger
+from collider.log import logger, should_disable_progress
 from collider.repository import search_packages
 from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson.scan import (
@@ -589,7 +588,7 @@ def resolve_dependencies(
         include_names=include_names,
         exclude_names=exclude_names,
     )
-    reporter = _ProgressReporter(disable=logger.level <= logging.DEBUG)
+    reporter = _ProgressReporter(disable=should_disable_progress())
     resolver = resolvelib.Resolver(provider, reporter)
 
     root_req = Requirement(root_name, root_version_spec)
@@ -655,7 +654,7 @@ def resolve_all_dependencies(
         exclude_optional=exclude_optional,
         root_overrides=root_overrides,
     )
-    reporter = _ProgressReporter(disable=logger.level <= logging.DEBUG)
+    reporter = _ProgressReporter(disable=should_disable_progress())
     resolver = resolvelib.Resolver(provider, reporter)
 
     root_reqs = [Requirement(r.name, r.version_spec) for r in roots]

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Tests for logging helpers."""
+
+from collider.log import Level, logger, should_disable_progress
+
+
+class _Stream:
+    """Small stream stub for progress output detection tests."""
+
+    def __init__(self, is_tty: bool):
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+
+def test_progress_enabled_for_interactive_info_output(monkeypatch) -> None:
+    """Interactive INFO output keeps progress bars enabled."""
+    original_level = logger.level
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.INFO.value)
+    try:
+        assert should_disable_progress(stream=_Stream(True)) is False
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_progress_disabled_for_non_tty_output(monkeypatch) -> None:
+    """Piped or redirected output disables animated progress bars."""
+    original_level = logger.level
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.INFO.value)
+    try:
+        assert should_disable_progress(stream=_Stream(False)) is True
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_progress_disabled_for_debug_logging(monkeypatch) -> None:
+    """Debug logs stay free of tqdm carriage-return output."""
+    original_level = logger.level
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.DEBUG.value)
+    try:
+        assert should_disable_progress(stream=_Stream(True)) is True
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_progress_disabled_in_ci(monkeypatch) -> None:
+    """CI logs suppress animated progress even if stdout reports as a TTY."""
+    original_level = logger.level
+    monkeypatch.setenv('CI', 'true')
+    logger.setLevel(Level.INFO.value)
+    try:
+        assert should_disable_progress(stream=_Stream(True)) is True
+    finally:
+        logger.setLevel(original_level)


### PR DESCRIPTION
﻿## Summary
- add a shared `should_disable_progress()` helper for progress-bar output
- disable tqdm bars when debug logging is active, stdout is not a TTY, or `CI` is truthy
- apply the helper to dependency resolution and transitive install progress bars
- add focused tests for interactive, non-TTY, debug, and CI behavior

Closes #47.

## Validation
- `python -m pip install -e .`
- `python -m pip install "ruff>=0.12.8"`
- `python -m ruff check collider/log.py collider/utils/packaging/resolver.py collider/subcommand/pkg/Add.py test/test_log.py`
- `python -m ruff format --check collider/log.py collider/utils/packaging/resolver.py collider/subcommand/pkg/Add.py test/test_log.py`
- `python -m pytest --no-cov test/test_log.py`
- `python -m pytest --no-cov test/utils/packaging/test_resolver.py::test_resolve_single_package_no_transitive test/utils/packaging/test_resolver.py::test_resolve_all_single_root_matches_resolve_dependencies`
- `python -m compileall collider test/test_log.py`

## Notes
- Running focused pytest without `--no-cov` passed the tests but failed the repo-wide coverage threshold because only a small subset was executed.
- Broader Windows-only focused runs exposed pre-existing environment/platform failures unrelated to this change, including missing `os.EX_*` constants on Windows and an existing prerelease-selection assertion in `test_provider_find_matches_excludes_prerelease_when_stable_exists` under the installed packaging stack.
