### PR TITLE
[codex] prune no-lockfile summary

### DIFF
--- a/collider/subcommand/pkg/Prune.py
+++ b/collider/subcommand/pkg/Prune.py
@@ -101,6 +101,7 @@ def run_prune(context: Context, dry_run: bool = False) -> int:
             'Run "collider lock" to create ownership metadata for future operations; '
             'existing leftover wraps may still need to be removed manually.'
         )
+        logger.warning('prune skipped: no lockfile; run "collider lock"')
         return os.EX_OK
 
     try:

--- a/test/subcommand/test_prune.py
+++ b/test/subcommand/test_prune.py
@@ -200,6 +200,7 @@ def test_prune_warns_without_lockfile(tmp_path: Path, caplog: pytest.LogCaptureF
     assert 'cannot safely determine which transitive wraps are orphaned' in caplog.text
     assert 'Run "collider lock" to create ownership metadata for future operations' in caplog.text
     assert 'may still need to be removed manually' in caplog.text
+    assert caplog.messages[-1] == 'prune skipped: no lockfile; run "collider lock"'
 
 
 def test_prune_warns_on_corrupt_lockfile(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
﻿This trims the no-lockfile prune path so it ends with a clear, script-friendly summary line.

Why:
- `pkg remove --prune` already behaves safely when there is no `collider.lock`
- the existing warning was easy to miss in automated output

Impact:
- the last log line now says `prune skipped: no lockfile; run "collider lock"`
- no exit-code change; the command still succeeds normally

Checks:
- `python -m pytest --no-cov test/subcommand/test_prune.py`
- `python -m ruff check collider/subcommand/pkg/Prune.py test/subcommand/test_prune.py`
- `python -m ruff format --check collider/subcommand/pkg/Prune.py test/subcommand/test_prune.py`
- `python -m compileall collider/subcommand/pkg/Prune.py test/subcommand/test_prune.py`
