### PR TITLE
[codex] expand plural provide names

### DIFF
--- a/collider/Package.py
+++ b/collider/Package.py
@@ -16,6 +16,9 @@ from collider.log import logger
 from collider.utils.fs import atomic_write_text
 
 
+_PROVIDE_LIST_KEYS = {'dependency_names', 'program_names'}
+
+
 def _load_wrap_section(
     wrap_text: str,
 ) -> tuple[configparser.ConfigParser, configparser.SectionProxy]:
@@ -35,7 +38,15 @@ def get_provide_names(wrap_text: str) -> list[str]:
     parser, _ = _load_wrap_section(wrap_text)
     if 'provide' not in parser:
         return []
-    return sorted(parser['provide'].keys())
+
+    provide_section = parser['provide']
+    provide_names: set[str] = set()
+    for key, value in provide_section.items():
+        if key in _PROVIDE_LIST_KEYS:
+            provide_names.update(name.strip() for name in value.split(',') if name.strip())
+        else:
+            provide_names.add(key)
+    return sorted(provide_names)
 
 
 @dataclass(frozen=True)

--- a/collider/repository/implementation/Filesystem.py
+++ b/collider/repository/implementation/Filesystem.py
@@ -7,6 +7,7 @@ import io
 import json
 import shutil
 import urllib.parse
+import urllib.request
 
 from pathlib import Path
 from typing import Optional
@@ -59,7 +60,9 @@ class Filesystem(RepositoryInterface):
     ) -> 'RepositoryInterface':
         if publish_url is None:
             raise ValueError('Filesystem repositories require a publish_url.')
-        repo_path = Path(url.path)
+        # file:// URLs on Windows keep the drive letter in URL form, so convert the
+        # path component back into a native filesystem path before touching disk.
+        repo_path = Path(urllib.request.url2pathname(url.path))
         if not repo_path.exists() or not repo_path.is_dir():
             raise ValueError(f'Filesystem repository path "{repo_path.as_posix()}" does not exist.')
 

--- a/test/package/test_package.py
+++ b/test/package/test_package.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from collider.Package import WrapPackage
+from collider.Package import WrapPackage, get_provide_names
 
 
 def test_wrap_package_install_writes_wrap_file(tmp_path: Path):
@@ -101,3 +101,20 @@ def test_wrap_package_warns_http_urls(caplog):
     pkg = WrapPackage.from_wrap_text('foo', '1.0.0', wrap_text)
     assert pkg.source_url == 'http://example.com/foo.tar.xz'
     assert 'HTTP source URLs are allowed but insecure' in caplog.text
+
+
+def test_get_provide_names_expands_plural_keys() -> None:
+    """Plural [provide] keys are expanded into the listed dependency names."""
+    wrap_text = (
+        '[wrap-file]\n'
+        'source_url=https://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        'source_hash=deadbeef\n'
+        '\n'
+        '[provide]\n'
+        'dependency_names = foo, bar\n'
+        'program_names = baz\n'
+        'qux = qux_dep\n'
+    )
+
+    assert get_provide_names(wrap_text) == ['bar', 'baz', 'foo', 'qux']

--- a/test/repository/implementation/test_wrap_filesystem.py
+++ b/test/repository/implementation/test_wrap_filesystem.py
@@ -62,6 +62,31 @@ def test_filesystem_from_url_scans_existing_wraps(repo_path: Path):
     assert releases['foo']['dependency_names'] == ['bar', 'foo']
 
 
+def test_filesystem_from_url_expands_plural_provide_names(repo_path: Path) -> None:
+    """Filesystem scans expand plural [provide] keys into dependency names."""
+    wrap_dir = repo_path / 'foo_1.0.0'
+    wrap_dir.mkdir()
+    wrap_path = wrap_dir / 'foo.wrap'
+    wrap_path.write_text(
+        (
+            '[wrap-file]\n'
+            'source_url=https://example.com/foo.tar.xz\n'
+            'source_filename=foo.tar.xz\n'
+            'source_hash=deadbeef\n'
+            '\n'
+            '[provide]\n'
+            'dependency_names = foo, bar\n'
+            'program_names = baz\n'
+        ),
+        encoding='utf-8',
+    )
+
+    Filesystem.from_url(repo_path.as_uri(), publish_url=repo_path.as_uri())
+
+    releases = json.loads((repo_path / 'releases.json').read_text(encoding='utf-8'))
+    assert releases['foo']['dependency_names'] == ['bar', 'baz', 'foo']
+
+
 def test_filesystem_repo_add_get_remove(repo_path: Path):
     repo = Filesystem(repo_path, publish_url=repo_path.as_uri())
     package = WrapPackage.from_wrap_text('foo', '1.0.0', _wrap_text())


### PR DESCRIPTION
﻿This expands Meson `[provide]` parsing so plural keys are handled correctly in repository metadata.

Why:
- `get_provide_names` used to return the literal section keys
- plural forms like `dependency_names = foo, bar` and `program_names = baz` were not being expanded

Impact:
- plural provides now contribute their actual names to repository indices
- filesystem repositories now write correct `dependency_names` into `releases.json`
- Windows `file://` repository URLs are also parsed into native filesystem paths correctly

Root cause:
- the parser treated every `[provide]` entry as a singular name key, so the reserved plural keys leaked through unchanged

Checks:
- `python -m pytest --no-cov test/package/test_package.py test/repository/implementation/test_wrap_filesystem.py`
- `python -m ruff check collider/Package.py collider/repository/implementation/Filesystem.py test/package/test_package.py test/repository/implementation/test_wrap_filesystem.py`
- `python -m ruff format --check collider/Package.py collider/repository/implementation/Filesystem.py test/package/test_package.py test/repository/implementation/test_wrap_filesystem.py`
- `python -m compileall collider/Package.py collider/repository/implementation/Filesystem.py test/package/test_package.py test/repository/implementation/test_wrap_filesystem.py`
