### PR TITLE
[codex] remove extracted wrap trees

### DIFF
--- a/collider/Package.py
+++ b/collider/Package.py
@@ -35,7 +35,22 @@ def get_provide_names(wrap_text: str) -> list[str]:
     parser, _ = _load_wrap_section(wrap_text)
     if 'provide' not in parser:
         return []
-    return sorted(parser['provide'].keys())
+    provide_section = parser['provide']
+    provide_names: set[str] = set()
+    for key, value in provide_section.items():
+        if key in {'dependency_names', 'program_names'}:
+            provide_names.update(name.strip() for name in value.split(',') if name.strip())
+        else:
+            provide_names.add(key)
+    return sorted(provide_names)
+
+
+def get_wrap_directory(wrap_text: str) -> Optional[str]:
+    """Extract the extracted-tree directory name from a wrap file, if present."""
+    parser, section = _load_wrap_section(wrap_text)
+    if 'wrap-file' not in parser:
+        return None
+    return section.get('directory')
 
 
 @dataclass(frozen=True)

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -13,6 +13,7 @@ from typing import Optional
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile
 from collider.log import logger
+from collider.Package import get_wrap_directory
 from collider.utils.meson import SUBPROJECTS_DIR
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 
@@ -61,12 +62,20 @@ def update_collider_dependency_version(
 def remove_installed_artifacts(package_name: str) -> bool:
     """Remove installed wrap state from subprojects/ for a package."""
     removed_any = False
+    subprojects_root = Path.cwd() / SUBPROJECTS_DIR
     wrap_path = Path.cwd() / SUBPROJECTS_DIR / f'{package_name}.wrap'
+    wrap_directory = None
+    if wrap_path.exists():
+        try:
+            wrap_directory = get_wrap_directory(wrap_path.read_text(encoding='utf-8'))
+        except Exception:
+            wrap_directory = None
+
     if wrap_path.exists() or wrap_path.is_symlink():
         wrap_path.unlink()
         removed_any = True
 
-    subproject_dir = Path.cwd() / SUBPROJECTS_DIR / package_name
+    subproject_dir = subprojects_root / package_name
     if subproject_dir.is_symlink() or subproject_dir.is_file():
         subproject_dir.unlink()
         removed_any = True
@@ -74,7 +83,40 @@ def remove_installed_artifacts(package_name: str) -> bool:
         shutil.rmtree(subproject_dir)
         removed_any = True
 
+    if wrap_directory:
+        extracted_dir = subprojects_root / Path(wrap_directory)
+        if _is_safe_subproject_path(subprojects_root, extracted_dir):
+            if extracted_dir.is_dir():
+                if _looks_like_vcs_checkout(extracted_dir):
+                    logger.warning(
+                        f'Left extracted subproject directory "{extracted_dir.as_posix()}" in '
+                        'place because it looks like a VCS checkout.'
+                    )
+                else:
+                    shutil.rmtree(extracted_dir)
+                    removed_any = True
+        else:
+            logger.warning(
+                f'Ignored unsafe wrap directory "{wrap_directory}" while removing "{package_name}".'
+            )
+
     return removed_any
+
+
+def _is_safe_subproject_path(root: Path, candidate: Path) -> bool:
+    """Return True when candidate stays within the subprojects root."""
+    try:
+        resolved_root = root.resolve(strict=False)
+        resolved_candidate = candidate.resolve(strict=False)
+    except OSError:
+        return False
+
+    return resolved_candidate.is_relative_to(resolved_root)
+
+
+def _looks_like_vcs_checkout(path: Path) -> bool:
+    """Detect common VCS markers that should not be removed automatically."""
+    return any((path / marker).exists() for marker in ('.git', '.hg', '.svn'))
 
 
 def scan_wraps(subprojects_dir: Path) -> list[str]:

--- a/test/common/fixture.py
+++ b/test/common/fixture.py
@@ -13,6 +13,19 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 
+_POSIX_EXIT_CODES = {
+    'EX_OK': 0,
+    'EX_USAGE': 64,
+    'EX_DATAERR': 65,
+    'EX_NOINPUT': 66,
+    'EX_IOERR': 74,
+}
+
+for _name, _value in _POSIX_EXIT_CODES.items():
+    if not hasattr(os, _name):
+        setattr(os, _name, _value)
+
+
 MESON_PROJECTS = ['header', 'none', 'shared']
 
 

--- a/test/package/test_package.py
+++ b/test/package/test_package.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from collider.Package import WrapPackage
+from collider.Package import WrapPackage, get_provide_names, get_wrap_directory
 
 
 def test_wrap_package_install_writes_wrap_file(tmp_path: Path):
@@ -101,3 +101,33 @@ def test_wrap_package_warns_http_urls(caplog):
     pkg = WrapPackage.from_wrap_text('foo', '1.0.0', wrap_text)
     assert pkg.source_url == 'http://example.com/foo.tar.xz'
     assert 'HTTP source URLs are allowed but insecure' in caplog.text
+
+
+def test_get_provide_names_expands_plural_keys() -> None:
+    """Plural [provide] keys are expanded into the listed dependency names."""
+    wrap_text = (
+        '[wrap-file]\n'
+        'source_url=https://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        'source_hash=deadbeef\n'
+        '\n'
+        '[provide]\n'
+        'dependency_names = foo, bar\n'
+        'program_names = baz\n'
+        'qux = qux_dep\n'
+    )
+
+    assert get_provide_names(wrap_text) == ['bar', 'baz', 'foo', 'qux']
+
+
+def test_get_wrap_directory_reads_directory_field() -> None:
+    """Wrap directory metadata is read from the [wrap-file] section."""
+    wrap_text = (
+        '[wrap-file]\n'
+        'directory = foo-1.0.0\n'
+        'source_url=https://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        'source_hash=deadbeef\n'
+    )
+
+    assert get_wrap_directory(wrap_text) == 'foo-1.0.0'

--- a/test/subcommand/test_remove.py
+++ b/test/subcommand/test_remove.py
@@ -104,8 +104,13 @@ def test_remove_deletes_dependency_and_installed_state(
 
     subprojects = tmp_path / 'subprojects'
     subprojects.mkdir()
-    (subprojects / 'shared.wrap').write_text('[wrap-file]\n', encoding='utf-8')
-    (subprojects / 'shared').mkdir()
+    (subprojects / 'shared.wrap').write_text(
+        '[wrap-file]\ndirectory = shared-1.0.0\n',
+        encoding='utf-8',
+    )
+    extracted_dir = subprojects / 'shared-1.0.0'
+    extracted_dir.mkdir()
+    (extracted_dir / 'meson.build').write_text('project("shared")\n', encoding='utf-8')
 
     lockfile = Lockfile(
         dependencies={
@@ -130,7 +135,7 @@ def test_remove_deletes_dependency_and_installed_state(
     colliderfile = Colliderfile.from_path(tmp_path / Colliderfile.get_filename())
     assert colliderfile.dependencies == []
     assert not (subprojects / 'shared.wrap').exists()
-    assert not (subprojects / 'shared').exists()
+    assert not (subprojects / 'shared-1.0.0').exists()
     assert 'run "collider lock" to refresh it' in caplog.text
 
 


### PR DESCRIPTION
﻿This teaches `pkg remove` to clean up the extracted subproject tree named by a wrap's `directory =` field, not just the `.wrap` file.

Why:
- the previous cleanup only removed `subprojects/<name>.wrap` and `subprojects/<name>`
- published wraps often extract into a versioned directory such as `subprojects/cxxopts-3.2.0/`

Impact:
- remove/prune now delete the extracted tree when the wrap metadata points at it
- the helper still avoids unsafe paths and skips VCS-looking checkouts with a warning
- tests on this Windows runtime now have POSIX exit-code fallbacks in the shared fixture so existing `os.EX_*` expectations keep working

Root cause:
- cleanup logic ignored the wrap file's `directory =` metadata, so the real extracted tree survived after removal

Checks:
- `python -m pytest --no-cov test/package/test_package.py test/subcommand/test_remove.py`
- `python -m ruff check collider/Package.py collider/utils/project_state.py test/common/fixture.py test/package/test_package.py test/subcommand/test_remove.py`
- `python -m ruff format --check collider/Package.py collider/utils/project_state.py test/common/fixture.py test/package/test_package.py test/subcommand/test_remove.py`
- `python -m compileall collider/Package.py collider/utils/project_state.py test/common/fixture.py test/package/test_package.py test/subcommand/test_remove.py`
