### PR TITLE
[codex] resolve provided dependency names in check

### DIFF
--- a/collider/subcommand/Check.py
+++ b/collider/subcommand/Check.py
@@ -13,10 +13,12 @@ from pathlib import Path
 from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.log import logger
+from collider.Package import get_provide_names
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
 from collider.utils.meson.scan import filter_dependencies, scan_dependencies
 from collider.utils.packaging.Dependency import DependencySource
+from collider.utils.packaging.resolver import build_dep_name_index
 
 
 _DEFAULT_SOURCE_DIR = Path('.')
@@ -38,7 +40,8 @@ class Check(SubcommandInterface):
             'Scan meson.build for dependency() calls and compare against collider.json.\n'
             'Reports untracked dependencies (in meson.build but not in collider.json) and\n'
             'stale entries (in collider.json but absent from meson.build).\n\n'
-            'Assumes the dependency() name in meson.build matches the collider package name.\n'
+            'Resolves dependency() names through installed wrap provides and repository\n'
+            'metadata when available.\n'
             'Exits with EX_DATAERR when drift is found, EX_OK when clean.'
         )
 
@@ -93,6 +96,8 @@ class Check(SubcommandInterface):
         scanned = scan_dependencies(meson_build)
         filtered = filter_dependencies(scanned, include_conditional=self.include_conditional)
 
+        dep_name_index = self._build_dependency_name_index()
+
         # Stale check uses the raw scan so conditional deps are not falsely flagged.
         scanned_all_names = {dep.name for dep in scanned}
         scanned_included_names = {dep.name for dep in filtered.included}
@@ -101,8 +106,13 @@ class Check(SubcommandInterface):
             dep.name for dep in colliderfile.dependencies if dep.source == DependencySource.COLLIDER
         }
 
-        untracked = sorted(scanned_included_names - collider_names)
-        stale = sorted(managed_names - scanned_all_names)
+        resolved_scanned_names = {dep_name_index.get(name, name) for name in scanned_all_names}
+        untracked = sorted(
+            name
+            for name in scanned_included_names
+            if dep_name_index.get(name, name) not in collider_names
+        )
+        stale = sorted(managed_names - resolved_scanned_names)
 
         for name in untracked:
             logger.error(
@@ -117,3 +127,29 @@ class Check(SubcommandInterface):
 
         logger.info('No drift detected.')
         return os.EX_OK
+
+    def _build_dependency_name_index(self) -> dict[str, str]:
+        """Resolve Meson dependency names to collider package names when possible."""
+        dep_name_index: dict[str, str] = {}
+
+        subprojects_dir = self.sourcedir / 'subprojects'
+        if subprojects_dir.exists():
+            for wrap_path in subprojects_dir.glob('*.wrap'):
+                package_name = wrap_path.stem
+                dep_name_index.setdefault(package_name, package_name)
+                try:
+                    provide_names = get_provide_names(wrap_path.read_text(encoding='utf-8'))
+                except Exception:
+                    continue
+                for provide_name in provide_names:
+                    dep_name_index.setdefault(provide_name, package_name)
+
+        repos = dict(getattr(self.context.config, 'repositories', {}).items())
+        dep_name_index.update(
+            {
+                name: package_name
+                for name, package_name in build_dep_name_index(repos).items()
+                if name not in dep_name_index
+            }
+        )
+        return dep_name_index

--- a/test/common/fixture.py
+++ b/test/common/fixture.py
@@ -13,6 +13,19 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 
+_POSIX_EXIT_CODES = {
+    'EX_OK': 0,
+    'EX_USAGE': 64,
+    'EX_DATAERR': 65,
+    'EX_NOINPUT': 66,
+    'EX_UNAVAILABLE': 69,
+    'EX_IOERR': 74,
+}
+
+for _name, _value in _POSIX_EXIT_CODES.items():
+    if not hasattr(os, _name):
+        setattr(os, _name, _value)
+
 MESON_PROJECTS = ['header', 'none', 'shared']
 
 

--- a/test/subcommand/test_check.py
+++ b/test/subcommand/test_check.py
@@ -3,12 +3,18 @@
 
 """Test the check subcommand."""
 
+import argparse
 import os
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from collider.cache import WrapCache
+from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
+from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.subcommand.Check import Check
 from collider.utils.meson.scan import ScannedDependency
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from test.common.common import Subcommand, run_subcommand
@@ -28,6 +34,14 @@ def _run_check(tmp_path: Path, extra_args: list[str] | None = None) -> int:
 def _mock_scan(deps: list[ScannedDependency]):
     """Patch scan_dependencies in the Check module."""
     return patch('collider.subcommand.Check.scan_dependencies', return_value=deps)
+
+
+def _make_context(tmp_path: Path, repos: dict | None = None) -> Context:
+    """Build a context with optional repositories for direct command tests."""
+    config = MagicMock()
+    config.repositories = repos or {}
+    config.offline = False
+    return Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
 
 
 def test_check_clean(tmp_path: Path) -> None:
@@ -92,3 +106,52 @@ def test_check_missing_collider_json(tmp_path: Path) -> None:
     (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
 
     assert _run_check(tmp_path) == os.EX_NOINPUT
+
+
+def test_check_resolves_provided_dependency_from_installed_wrap(
+    tmp_path: Path,
+) -> None:
+    """Installed wrap provides should satisfy dependency drift checks."""
+    _make_project(tmp_path, [Dependency('catch2', DependencySource.COLLIDER, None)])
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir()
+    (subprojects / 'catch2.wrap').write_text(
+        (
+            '[wrap-file]\n'
+            'source_url=https://example.com/catch2.tar.xz\n'
+            'source_filename=catch2.tar.xz\n'
+            'source_hash=deadbeef\n'
+            '\n'
+            '[provide]\n'
+            'catch2 = catch2_dep\n'
+            'catch2-with-main = catch2_with_main_dep\n'
+        ),
+        encoding='utf-8',
+    )
+
+    cmd = Check(
+        argparse.Namespace(sourcedir=tmp_path, include_conditional=False),
+        _make_context(tmp_path),
+    )
+
+    with _mock_scan([ScannedDependency('catch2-with-main', required=True)]):
+        assert cmd.execute() == os.EX_OK
+
+
+def test_check_falls_back_to_repo_dependency_names(tmp_path: Path) -> None:
+    """Repository dependency_names metadata resolves dependency drift when wraps are absent."""
+    _make_project(tmp_path, [Dependency('catch2', DependencySource.COLLIDER, None)])
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {
+        'catch2@3.0.0#wrap': RepoPackageEntry(
+            'catch2', '3.0.0', dependency_names=['catch2-with-main']
+        ),
+    }
+    cmd = Check(
+        argparse.Namespace(sourcedir=tmp_path, include_conditional=False),
+        _make_context(tmp_path, {'repo1': repo}),
+    )
+
+    with _mock_scan([ScannedDependency('catch2-with-main', required=True)]):
+        assert cmd.execute() == os.EX_OK


### PR DESCRIPTION
﻿This makes `collider check` resolve dependency names through installed wrap provides first, then repository dependency metadata, so package aliases no longer false-fail drift checks.

Why:
- `check` previously compared raw Meson `dependency()` names directly against Collider package names
- packages like `catch2` can provide `catch2-with-main`, which should count as satisfied

Impact:
- installed wraps with `[provide]` aliases now satisfy `check`
- repository `dependency_names` metadata is used as a fallback when no installed wrap provides the alias
- stale detection now treats an alias as coverage for the owning package, not as drift
- the shared test fixture now defines the POSIX `os.EX_*` constants missing on this Windows runtime so CLI exit-code tests stay portable

Root cause:
- `check` assumed `dependency()` names and package names were always identical

Checks:
- `python -m pytest --no-cov test/subcommand/test_check.py test/contract/test_check_exit_codes.py`
- `python -m ruff check collider/subcommand/Check.py test/common/fixture.py test/subcommand/test_check.py test/contract/test_check_exit_codes.py`
- `python -m ruff format --check collider/subcommand/Check.py test/common/fixture.py test/subcommand/test_check.py test/contract/test_check_exit_codes.py`
- `python -m compileall collider/subcommand/Check.py test/common/fixture.py test/subcommand/test_check.py test/contract/test_check_exit_codes.py`
