### PR TITLE
feat(check): resolve provided dependency names so aliases are not drift

### DIFF
--- a/collider/Package.py
+++ b/collider/Package.py
@@ -16,13 +16,19 @@ from collider.log import logger
 from collider.utils.fs import atomic_write_text
 
 
+def _parse_wrap(wrap_text: str) -> configparser.ConfigParser:
+    """Parse wrap text with the case-sensitive, interpolation-free options wraps require."""
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str  # ty: ignore[invalid-assignment]
+    parser.read_string(wrap_text)
+    return parser
+
+
 def _load_wrap_section(
     wrap_text: str,
 ) -> tuple[configparser.ConfigParser, configparser.SectionProxy]:
     """Parse wrap text once so validation rules stay consistent."""
-    parser = configparser.ConfigParser(interpolation=None)
-    parser.optionxform = str  # ty: ignore[invalid-assignment]
-    parser.read_string(wrap_text)
+    parser = _parse_wrap(wrap_text)
 
     if 'wrap-file' not in parser:
         raise ValueError('Unsupported wrap file format. Expected [wrap-file] section.')
@@ -31,11 +37,27 @@ def _load_wrap_section(
 
 
 def get_provide_names(wrap_text: str) -> list[str]:
-    """Extract provided dependency names from a wrap file."""
-    parser, _ = _load_wrap_section(wrap_text)
+    """
+    Extract provided dependency names from a wrap file, regardless of wrap type.
+    The [provide] section is valid in any wrap kind, so this does not require [wrap-file].
+    Meson's reserved ``dependency_names`` key holds a comma-separated list, ``program_names``
+    holds find_program() entries (not dependency() names), and every other key is itself a
+    provided dependency name.
+    :param wrap_text: Raw wrap file contents.
+    :return: Sorted, de-duplicated provided dependency names.
+    """
+    parser = _parse_wrap(wrap_text)
     if 'provide' not in parser:
         return []
-    return sorted(parser['provide'].keys())
+    names: set[str] = set()
+    for key, value in parser['provide'].items():
+        if key == 'dependency_names':
+            names.update(name.strip() for name in value.split(',') if name.strip())
+        elif key == 'program_names':
+            continue
+        else:
+            names.add(key)
+    return sorted(names)
 
 
 @dataclass(frozen=True)

--- a/collider/repository/implementation/Filesystem.py
+++ b/collider/repository/implementation/Filesystem.py
@@ -263,7 +263,15 @@ class Filesystem(RepositoryInterface):
                 if not version:
                     logger.debug(f'Skipping wrap "{wrap_path.name}" with missing version.')
                     continue
-                provide_names = get_provide_names(wrap_path.read_text(encoding='utf-8')) or None
+                wrap_text = wrap_path.read_text(encoding='utf-8')
+                try:
+                    # Published packages must be wrap-file based; reject git/redirect wraps loudly
+                    # rather than scanning them into a broken releases.json entry.
+                    _load_wrap_section(wrap_text)
+                except ValueError:
+                    logger.error(f'Skipping non-wrap-file package wrap "{wrap_path.name}".')
+                    continue
+                provide_names = get_provide_names(wrap_text) or None
                 add_wrap_entry(packages, name, version, provide_names)
         return packages
 

--- a/collider/subcommand/Check.py
+++ b/collider/subcommand/Check.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import argparse
+import configparser
 import os
 
 from pathlib import Path
@@ -13,10 +14,12 @@ from pathlib import Path
 from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.log import logger
+from collider.Package import get_provide_names
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
 from collider.utils.meson.scan import filter_dependencies, scan_dependencies
 from collider.utils.packaging.Dependency import DependencySource
+from collider.utils.packaging.resolver import build_dep_name_index
 
 
 _DEFAULT_SOURCE_DIR = Path('.')
@@ -38,7 +41,9 @@ class Check(SubcommandInterface):
             'Scan meson.build for dependency() calls and compare against collider.json.\n'
             'Reports untracked dependencies (in meson.build but not in collider.json) and\n'
             'stale entries (in collider.json but absent from meson.build).\n\n'
-            'Assumes the dependency() name in meson.build matches the collider package name.\n'
+            'Resolves dependency() names through installed wrap provides and repository\n'
+            'metadata so package aliases (e.g. catch2 providing catch2-with-main) are not\n'
+            'mistaken for drift.\n'
             'Exits with EX_DATAERR when drift is found, EX_OK when clean.'
         )
 
@@ -93,6 +98,8 @@ class Check(SubcommandInterface):
         scanned = scan_dependencies(meson_build)
         filtered = filter_dependencies(scanned, include_conditional=self.include_conditional)
 
+        dep_name_index = self._build_dependency_name_index()
+
         # Stale check uses the raw scan so conditional deps are not falsely flagged.
         scanned_all_names = {dep.name for dep in scanned}
         scanned_included_names = {dep.name for dep in filtered.included}
@@ -101,8 +108,21 @@ class Check(SubcommandInterface):
             dep.name for dep in colliderfile.dependencies if dep.source == DependencySource.COLLIDER
         }
 
-        untracked = sorted(scanned_included_names - collider_names)
-        stale = sorted(managed_names - scanned_all_names)
+        # A scanned dependency is covered when its own name or its owning package is tracked;
+        # resolution only rescues aliases the user has not already tracked directly.
+        untracked = sorted(
+            {
+                dep_name_index.get(name, name)
+                for name in scanned_included_names
+                if name not in collider_names
+                and dep_name_index.get(name, name) not in collider_names
+            }
+        )
+        # A managed package is used when it is scanned directly or a dependency resolves to it.
+        used_names = scanned_all_names | {
+            dep_name_index.get(name, name) for name in scanned_all_names
+        }
+        stale = sorted(managed_names - used_names)
 
         for name in untracked:
             logger.error(
@@ -117,3 +137,32 @@ class Check(SubcommandInterface):
 
         logger.info('No drift detected.')
         return os.EX_OK
+
+    def _build_dependency_name_index(self) -> dict[str, str]:
+        """
+        Map Meson dependency() names to their owning collider package name.
+        Installed wrap [provide] aliases take precedence over repository metadata, which only
+        fills gaps for packages whose wrap is not present in the local subprojects directory.
+        :return: Mapping from dependency name to collider package name.
+        """
+        index: dict[str, str] = {}
+
+        subprojects_dir = self.sourcedir / 'subprojects'
+        if subprojects_dir.exists():
+            for wrap_path in subprojects_dir.glob('*.wrap'):
+                if not wrap_path.is_file():
+                    continue
+                package_name = wrap_path.stem
+                index.setdefault(package_name, package_name)
+                try:
+                    provide_names = get_provide_names(wrap_path.read_text(encoding='utf-8'))
+                except (ValueError, OSError, configparser.Error):
+                    continue
+                for provide_name in provide_names:
+                    index.setdefault(provide_name, package_name)
+
+        repos = dict(self.context.config.repositories.items())
+        for name, package_name in build_dep_name_index(repos).items():
+            index.setdefault(name, package_name)
+
+        return index

--- a/test/package/test_package.py
+++ b/test/package/test_package.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from collider.Package import WrapPackage
+from collider.Package import WrapPackage, get_provide_names
 
 
 def test_wrap_package_install_writes_wrap_file(tmp_path: Path):
@@ -101,3 +101,31 @@ def test_wrap_package_warns_http_urls(caplog):
     pkg = WrapPackage.from_wrap_text('foo', '1.0.0', wrap_text)
     assert pkg.source_url == 'http://example.com/foo.tar.xz'
     assert 'HTTP source URLs are allowed but insecure' in caplog.text
+
+
+def test_get_provide_names_returns_named_provide_keys():
+    wrap_text = (
+        '[wrap-file]\nsource_url=x\n\n[provide]\ncatch2 = catch2_dep\ncatch2-with-main = m\n'
+    )
+    assert get_provide_names(wrap_text) == ['catch2', 'catch2-with-main']
+
+
+def test_get_provide_names_expands_reserved_dependency_names():
+    wrap_text = (
+        '[wrap-file]\nsource_url=x\n\n[provide]\ndependency_names = catch2-with-main, catch2\n'
+    )
+    assert get_provide_names(wrap_text) == ['catch2', 'catch2-with-main']
+
+
+def test_get_provide_names_excludes_program_names():
+    wrap_text = '[wrap-file]\nsource_url=x\n\n[provide]\nfoo = foo_dep\nprogram_names = cmake\n'
+    assert get_provide_names(wrap_text) == ['foo']
+
+
+def test_get_provide_names_reads_git_wrap_provide():
+    wrap_text = '[wrap-git]\nurl=https://example.invalid/foo.git\n\n[provide]\nfoo = foo_dep\n'
+    assert get_provide_names(wrap_text) == ['foo']
+
+
+def test_get_provide_names_without_provide_section_returns_empty():
+    assert get_provide_names('[wrap-git]\nurl=https://example.invalid/foo.git\n') == []

--- a/test/repository/implementation/test_wrap_filesystem.py
+++ b/test/repository/implementation/test_wrap_filesystem.py
@@ -62,6 +62,22 @@ def test_filesystem_from_url_scans_existing_wraps(repo_path: Path):
     assert releases['foo']['dependency_names'] == ['bar', 'foo']
 
 
+def test_filesystem_scan_skips_non_wrap_file_package(repo_path: Path, caplog):
+    wrap_dir = repo_path / 'foo_1.0.0'
+    wrap_dir.mkdir()
+    (wrap_dir / 'foo.wrap').write_text(
+        '[wrap-git]\nurl=https://example.invalid/foo.git\nrevision=head\n', encoding='utf-8'
+    )
+
+    caplog.set_level('ERROR')
+    repo = Filesystem.from_url(repo_path.as_uri(), publish_url=repo_path.as_uri())
+
+    assert repo.packages == {}
+    assert 'Skipping non-wrap-file package wrap "foo.wrap".' in caplog.text
+    releases = json.loads((repo_path / 'releases.json').read_text(encoding='utf-8'))
+    assert releases == {}
+
+
 def test_filesystem_repo_add_get_remove(repo_path: Path):
     repo = Filesystem(repo_path, publish_url=repo_path.as_uri())
     package = WrapPackage.from_wrap_text('foo', '1.0.0', _wrap_text())

--- a/test/subcommand/test_check.py
+++ b/test/subcommand/test_check.py
@@ -3,12 +3,20 @@
 
 """Test the check subcommand."""
 
+import argparse
 import os
 
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from collider.cache import WrapCache
+from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
+from collider.repository.entries import RepoPackageEntry
+from collider.subcommand.Check import Check
 from collider.utils.meson.scan import ScannedDependency
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from test.common.common import Subcommand, run_subcommand
@@ -28,6 +36,50 @@ def _run_check(tmp_path: Path, extra_args: list[str] | None = None) -> int:
 def _mock_scan(deps: list[ScannedDependency]):
     """Patch scan_dependencies in the Check module."""
     return patch('collider.subcommand.Check.scan_dependencies', return_value=deps)
+
+
+def _write_wrap(tmp_path: Path, stem: str, text: str) -> None:
+    """Write a wrap file into <tmp_path>/subprojects, creating the directory if needed."""
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir(exist_ok=True)
+    (subprojects / f'{stem}.wrap').write_text(text, encoding='utf-8')
+
+
+def _provide_wrap(provides: list[str]) -> str:
+    """Build [wrap-file] text whose [provide] section declares the given dependency names."""
+    text = (
+        '[wrap-file]\n'
+        'source_url = https://example.invalid/x.tar.xz\n'
+        'source_filename = x.tar.xz\n'
+        'source_hash = deadbeef\n'
+    )
+    if provides:
+        body = ''.join(f'{name} = {name.replace("-", "_")}_dep\n' for name in provides)
+        text += f'\n[provide]\n{body}'
+    return text
+
+
+def _repo(*entries: RepoPackageEntry) -> SimpleNamespace:
+    """Build a stub repository exposing the given package entries."""
+    return SimpleNamespace(packages={f'{e.name}@{e.version}': e for e in entries})
+
+
+def _make_check(
+    tmp_path: Path,
+    repos: dict | None = None,
+    include_conditional: bool = False,
+) -> Check:
+    """Build a Check command bound to tmp_path with optional configured repositories."""
+    config = MagicMock()
+    config.repositories = repos or {}
+    context = Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
+    args = argparse.Namespace(sourcedir=tmp_path, include_conditional=include_conditional)
+    return Check(args, context)
+
+
+def _index(tmp_path: Path, repos: dict | None = None) -> dict[str, str]:
+    """Build the dependency-name resolution index for the given project state."""
+    return _make_check(tmp_path, repos)._build_dependency_name_index()
 
 
 def test_check_clean(tmp_path: Path) -> None:
@@ -92,3 +144,253 @@ def test_check_missing_collider_json(tmp_path: Path) -> None:
     (tmp_path / 'meson.build').write_text('project("demo", "c")\n')
 
     assert _run_check(tmp_path) == os.EX_NOINPUT
+
+
+# --- Resolution index: how dependency() names map to their owning package ---
+
+
+def test_index_is_empty_without_wraps_or_repos(tmp_path: Path) -> None:
+    assert _index(tmp_path) == {}
+
+
+def test_index_maps_wrap_stem_and_named_provides(tmp_path: Path) -> None:
+    _write_wrap(tmp_path, 'catch2', _provide_wrap(['catch2', 'catch2-with-main']))
+
+    assert _index(tmp_path) == {'catch2': 'catch2', 'catch2-with-main': 'catch2'}
+
+
+def test_index_expands_reserved_dependency_names(tmp_path: Path) -> None:
+    _write_wrap(
+        tmp_path,
+        'catch2',
+        '[wrap-file]\nsource_url = x\n\n[provide]\ndependency_names = catch2-with-main, catch2\n',
+    )
+
+    assert _index(tmp_path) == {'catch2': 'catch2', 'catch2-with-main': 'catch2'}
+
+
+def test_index_reads_git_wrap_provides(tmp_path: Path) -> None:
+    _write_wrap(
+        tmp_path,
+        'catch2',
+        '[wrap-git]\nurl = https://example.invalid/catch2.git\n\n[provide]\ncatch2-with-main = m\n',
+    )
+
+    assert _index(tmp_path) == {'catch2': 'catch2', 'catch2-with-main': 'catch2'}
+
+
+def test_index_excludes_program_names(tmp_path: Path) -> None:
+    _write_wrap(
+        tmp_path,
+        'foo',
+        '[wrap-file]\nsource_url = x\n\n[provide]\nfoo = foo_dep\nprogram_names = cmake\n',
+    )
+
+    assert _index(tmp_path) == {'foo': 'foo'}
+
+
+def test_index_maps_stem_for_wrap_without_provide(tmp_path: Path) -> None:
+    _write_wrap(tmp_path, 'zlib', _provide_wrap([]))
+
+    assert _index(tmp_path) == {'zlib': 'zlib'}
+
+
+def test_index_keeps_stem_when_provides_are_unparseable(tmp_path: Path) -> None:
+    """A malformed wrap still maps its stem; only its unreadable provides are dropped."""
+    _write_wrap(tmp_path, 'broken', 'not an ini file, no section header\n')
+
+    assert _index(tmp_path) == {'broken': 'broken'}
+
+
+def test_index_keeps_stem_for_undecodable_wrap(tmp_path: Path) -> None:
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir()
+    (subprojects / 'bad.wrap').write_bytes(b'\xff\xfe\x00not utf-8')
+
+    assert _index(tmp_path) == {'bad': 'bad'}
+
+
+def test_index_ignores_directory_named_like_a_wrap(tmp_path: Path) -> None:
+    (tmp_path / 'subprojects').mkdir()
+    (tmp_path / 'subprojects' / 'dir.wrap').mkdir()
+
+    assert _index(tmp_path) == {}
+
+
+def test_index_merges_multiple_wraps(tmp_path: Path) -> None:
+    _write_wrap(tmp_path, 'fmt', _provide_wrap(['fmt']))
+    _write_wrap(tmp_path, 'spdlog', _provide_wrap(['spdlog']))
+
+    assert _index(tmp_path) == {'fmt': 'fmt', 'spdlog': 'spdlog'}
+
+
+def test_index_fills_gaps_from_repo_metadata(tmp_path: Path) -> None:
+    repos = {'r': _repo(RepoPackageEntry('catch2', '3.0.0', dependency_names=['catch2-with-main']))}
+
+    assert _index(tmp_path, repos) == {'catch2-with-main': 'catch2'}
+
+
+def test_index_prefers_installed_wrap_over_repo_metadata(tmp_path: Path) -> None:
+    """An installed wrap's provide wins over conflicting repository metadata."""
+    _write_wrap(tmp_path, 'catch2', _provide_wrap(['catch2-with-main']))
+    repos = {'r': _repo(RepoPackageEntry('other', '1.0.0', dependency_names=['catch2-with-main']))}
+
+    assert _index(tmp_path, repos)['catch2-with-main'] == 'catch2'
+
+
+# --- Drift detection: where resolved names are used in the untracked/stale verdict ---
+
+
+_DRIFT_SCENARIOS = [
+    pytest.param(
+        [('fmt', DependencySource.COLLIDER)],
+        {},
+        [('fmt', False)],
+        False,
+        os.EX_OK,
+        id='direct-tracked-clean',
+    ),
+    pytest.param(
+        [('fmt', DependencySource.COLLIDER)],
+        {},
+        [('spdlog', False)],
+        False,
+        os.EX_DATAERR,
+        id='unrelated-dep-untracked-and-stale',
+    ),
+    pytest.param(
+        [('catch2', DependencySource.COLLIDER)],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', False)],
+        False,
+        os.EX_OK,
+        id='alias-resolves-to-tracked-package',
+    ),
+    pytest.param(
+        [],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', False)],
+        False,
+        os.EX_DATAERR,
+        id='alias-resolves-to-untracked-package',
+    ),
+    pytest.param(
+        [('catch2-with-main', DependencySource.SYSTEM)],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', False)],
+        False,
+        os.EX_OK,
+        id='alias-tracked-directly-as-system',
+    ),
+    pytest.param(
+        [('catch2-with-main', DependencySource.COLLIDER)],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', False)],
+        False,
+        os.EX_OK,
+        id='alias-tracked-directly-as-collider',
+    ),
+    pytest.param(
+        [('fmt', DependencySource.COLLIDER)],
+        {},
+        [],
+        False,
+        os.EX_DATAERR,
+        id='managed-unused-is-stale',
+    ),
+    pytest.param(
+        [('foo', DependencySource.COLLIDER)],
+        {'bar': ['foo']},
+        [('foo', False)],
+        False,
+        os.EX_OK,
+        id='managed-name-is-foreign-alias-used-directly',
+    ),
+    pytest.param(
+        [('zlib', DependencySource.SYSTEM)],
+        {},
+        [],
+        False,
+        os.EX_OK,
+        id='system-managed-never-stale',
+    ),
+    pytest.param(
+        [('catch2', DependencySource.COLLIDER)],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', True)],
+        False,
+        os.EX_OK,
+        id='conditional-alias-not-stale',
+    ),
+    pytest.param(
+        [],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', True)],
+        True,
+        os.EX_DATAERR,
+        id='include-conditional-resolves-untracked-alias',
+    ),
+    pytest.param(
+        [('catch2', DependencySource.COLLIDER), ('fmt', DependencySource.COLLIDER)],
+        {'catch2': ['catch2-with-main']},
+        [('catch2-with-main', False), ('fmt', False)],
+        False,
+        os.EX_OK,
+        id='multiple-mixed-clean',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'collider_deps, wraps, scanned, include_conditional, expected', _DRIFT_SCENARIOS
+)
+def test_check_drift_resolution(
+    tmp_path: Path,
+    collider_deps: list[tuple[str, DependencySource]],
+    wraps: dict[str, list[str]],
+    scanned: list[tuple[str, bool]],
+    include_conditional: bool,
+    expected: int,
+) -> None:
+    """Resolved names drive the untracked/stale verdict across tracking and provide states."""
+    _make_project(tmp_path, [Dependency(name, source, None) for name, source in collider_deps])
+    for stem, provides in wraps.items():
+        _write_wrap(tmp_path, stem, _provide_wrap(provides))
+    cmd = _make_check(tmp_path, include_conditional=include_conditional)
+
+    scanned_deps = [
+        ScannedDependency(name, required=True, conditional=cond) for name, cond in scanned
+    ]
+    with _mock_scan(scanned_deps):
+        assert cmd.execute() == expected
+
+
+def test_check_resolves_alias_via_repo_metadata(tmp_path: Path) -> None:
+    """With no installed wrap, repository metadata resolves the alias to its package."""
+    _make_project(tmp_path, [Dependency('catch2', DependencySource.COLLIDER, None)])
+    repos = {'r': _repo(RepoPackageEntry('catch2', '3.0.0', dependency_names=['catch2-with-main']))}
+    cmd = _make_check(tmp_path, repos)
+
+    with _mock_scan([ScannedDependency('catch2-with-main', required=True)]):
+        assert cmd.execute() == os.EX_OK
+
+
+def test_check_untracked_reports_resolved_package_name(tmp_path: Path, caplog) -> None:
+    """An untracked alias is reported under its owning package, so `pkg add` is actionable."""
+    _make_project(tmp_path, [])
+    _write_wrap(tmp_path, 'catch2', _provide_wrap(['catch2-with-main']))
+
+    with _mock_scan([ScannedDependency('catch2-with-main', required=True)]):
+        assert _run_check(tmp_path) == os.EX_DATAERR
+
+    assert 'collider pkg add catch2' in caplog.text
+    assert 'catch2-with-main' not in caplog.text
+
+
+def test_check_resolves_provide_from_installed_wrap(tmp_path: Path) -> None:
+    """End-to-end: an installed wrap's [provide] alias keeps `collider check` clean."""
+    _make_project(tmp_path, [Dependency('catch2', DependencySource.COLLIDER, None)])
+    _write_wrap(tmp_path, 'catch2', _provide_wrap(['catch2-with-main']))
+
+    with _mock_scan([ScannedDependency('catch2-with-main', required=True)]):
+        assert _run_check(tmp_path) == os.EX_OK

--- a/test/utils/test_project_state.py
+++ b/test/utils/test_project_state.py
@@ -80,6 +80,21 @@ def test_collect_non_wrap_file_uses_stem_only(tmp_path: Path) -> None:
     assert collect_force_fallback_names(subprojects) == ['mydep']
 
 
+def test_collect_git_wrap_with_provide_includes_aliases(tmp_path: Path) -> None:
+    """A git/redirect wrap carrying a [provide] section forces both its stem and its aliases."""
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(
+        subprojects,
+        'catch2',
+        '[wrap-git]\n'
+        'url = https://example.invalid/catch2.git\n'
+        'revision = head\n'
+        '\n[provide]\n'
+        'catch2-with-main = catch2_with_main_dep\n',
+    )
+    assert collect_force_fallback_names(subprojects) == ['catch2', 'catch2-with-main']
+
+
 def test_collect_malformed_ini_wrap_uses_stem_only(tmp_path: Path) -> None:
     """A wrap that is not parseable INI (no section header) is tolerated; the stem forces it."""
     subprojects = tmp_path / 'subprojects'


### PR DESCRIPTION
## What

`collider check` now resolves Meson `dependency()` names to their owning collider package before comparing against `collider.json`, so a package alias (e.g. `catch2` providing `catch2-with-main`) no longer false-fails drift detection.

## Credit

This builds on #57 by @hass-nation, which **identified a real issue**: `check` assumed `dependency()` names and collider package names were always identical, so installed wraps exposing `[provide]` aliases were wrongly flagged as drift. That diagnosis was correct and is the basis for this work -- credit to them for surfacing it.

This PR reimplements the fix at the root and closes gaps the original approach left open (see below). It supersedes #57.

## How

- **Root parser fix (`Package.py`)** -- `get_provide_names` previously required a `[wrap-file]` section (so `[wrap-git]`/`[wrap-redirect]` wraps raised and their provides were silently dropped) and returned the literal `[provide]` keys verbatim (mishandling Meson's reserved `dependency_names` comma-list and `program_names`). It now parses `[provide]` for any wrap type, expands `dependency_names`, and skips `program_names`. This also corrects force-fallback and `releases.json` generation, which share the helper.
- **Repository scan strictness (`Filesystem.py`)** -- since the helper no longer raises on non-wrap-file wraps, the repo scan now rejects them explicitly so a stray git/redirect wrap cannot land in a broken `releases.json` entry.
- **Resolution + verdict (`Check.py`)** -- a resolution index maps dependency names to packages from installed wrap `[provide]` aliases (preferred) and repository `dependency_names` metadata (fallback). A dependency is covered when **either its own name or its resolved package** is tracked, applied symmetrically to the untracked and stale checks. Untracked deps are reported under their owning package so `collider pkg add` stays actionable.

## Differences from #57

- Fixed at the root (`get_provide_names`) instead of only inside `check`, so the reserved-key and git/redirect-wrap cases are handled (the original broke on both).
- Resolution does not override a directly-tracked name, fixing a false-positive class for dependencies tracked as `system` (or any source) whose name is also a provide alias.
- Untracked output names the resolved package, not the raw alias.
- Narrow exception handling; preserves repo-scan strictness; drops a Windows-only `os.EX_*` test monkeypatch.

## Tests

Extensive coverage for both halves of the feature:
- **Name resolution** (`_build_dependency_name_index`): exact-map assertions for named provides, reserved-key expansion, git wraps, `program_names` exclusion, malformed/undecodable wraps (stem kept), directory-named-`*.wrap` guard, multi-wrap merge, repo gap-fill, and wrap-over-repo precedence.
- **Drift verdict**: parametrized matrix over tracking source x provide state x conditional flag, including regression guards for SYSTEM-tracked aliases and managed-name-is-a-foreign-alias.

`pytest` 743 passed / 1 skipped; `ruff format`, `ruff check`, `ty`, `pylint` (10/10) clean; `act` lint and pytest jobs pass.