### PR TITLE
fix(progress): hide tqdm bars outside interactive output (#47)

### DIFF
--- a/collider/log.py
+++ b/collider/log.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 from enum import Enum
-from typing import Callable, TextIO, cast
+from typing import Callable, Optional, TextIO, cast
 
 
 first_include = False
@@ -90,11 +90,18 @@ def configure_logging(verbose: bool) -> None:
     init_logger(Level.DEBUG if verbose else Level.INFO)
 
 
-def should_disable_progress(*, stream: TextIO | None = None) -> bool:
-    """Return whether animated progress output should be suppressed."""
+def should_disable_progress(*, stream: Optional[TextIO] = None) -> bool:
+    """
+    Return whether animated progress output should be suppressed.
+    Bars are hidden under debug logging (where they would interleave with verbose logs), under
+    CI, or when the output stream is not an interactive TTY. The stream defaults to stderr
+    because tqdm writes there, so a redirected stdout alone must not hide a terminal bar.
+    :param stream: Output stream to probe; defaults to the stderr tqdm writes to.
+    :return: True when progress bars should be disabled.
+    """
     ci_value = os.environ.get('CI', '').strip().lower()
     ci_enabled = ci_value not in ('', '0', 'false', 'no', 'off')
-    output = stream if stream is not None else sys.stdout
+    output = stream if stream is not None else sys.stderr
     return logger.level <= Level.DEBUG.value or ci_enabled or not output.isatty()
 
 

--- a/collider/log.py
+++ b/collider/log.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 from enum import Enum
-from typing import Callable, cast
+from typing import Callable, TextIO, cast
 
 
 first_include = False
@@ -88,6 +88,14 @@ def init_logger(level: Level) -> None:
 def configure_logging(verbose: bool) -> None:
     """Switch between concise and debug logging based on CLI flags."""
     init_logger(Level.DEBUG if verbose else Level.INFO)
+
+
+def should_disable_progress(*, stream: TextIO | None = None) -> bool:
+    """Return whether animated progress output should be suppressed."""
+    ci_value = os.environ.get('CI', '').strip().lower()
+    ci_enabled = ci_value not in ('', '0', 'false', 'no', 'off')
+    output = stream if stream is not None else sys.stdout
+    return logger.level <= Level.DEBUG.value or ci_enabled or not output.isatty()
 
 
 if not first_include:

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -4,7 +4,6 @@
 """Add a package dependency to the project."""
 
 import argparse
-import logging
 import os
 import re
 import shutil
@@ -22,7 +21,7 @@ from tqdm import tqdm
 from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile, compute_wrap_hash
-from collider.log import logger
+from collider.log import logger, should_disable_progress
 from collider.Package import WrapPackage
 from collider.repository import search_packages
 from collider.repository.entries import RepoPackageEntry
@@ -509,7 +508,7 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
             desc='Installing dependencies',
             unit='pkg',
             leave=False,
-            disable=not transitive_candidates or logger.level <= logging.DEBUG,
+            disable=not transitive_candidates or should_disable_progress(),
         )
         for pkg_name, candidate in progress:
             progress.set_postfix_str(pkg_name)

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import re
 import subprocess
 import tarfile
@@ -25,7 +24,7 @@ from packaging.version import InvalidVersion
 from tqdm import tqdm
 
 from collider.cache import WrapCache
-from collider.log import logger
+from collider.log import logger, should_disable_progress
 from collider.repository import search_packages
 from collider.utils.core import assert_safe_path_segment
 from collider.utils.meson.scan import (
@@ -589,7 +588,7 @@ def resolve_dependencies(
         include_names=include_names,
         exclude_names=exclude_names,
     )
-    reporter = _ProgressReporter(disable=logger.level <= logging.DEBUG)
+    reporter = _ProgressReporter(disable=should_disable_progress())
     resolver = resolvelib.Resolver(provider, reporter)
 
     root_req = Requirement(root_name, root_version_spec)
@@ -655,7 +654,7 @@ def resolve_all_dependencies(
         exclude_optional=exclude_optional,
         root_overrides=root_overrides,
     )
-    reporter = _ProgressReporter(disable=logger.level <= logging.DEBUG)
+    reporter = _ProgressReporter(disable=should_disable_progress())
     resolver = resolvelib.Resolver(provider, reporter)
 
     root_reqs = [Requirement(r.name, r.version_spec) for r in roots]

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -3,11 +3,15 @@
 
 """Tests for logging helpers."""
 
+import sys
+
+import pytest
+
 from collider.log import Level, logger, should_disable_progress
 
 
 class _Stream:
-    """Small stream stub for progress output detection tests."""
+    """Minimal stream stub reporting a fixed TTY status."""
 
     def __init__(self, is_tty: bool):
         self._is_tty = is_tty
@@ -16,45 +20,70 @@ class _Stream:
         return self._is_tty
 
 
+@pytest.fixture(autouse=True)
+def _restore_log_level():
+    """Keep a test's logger-level change from leaking into the next test."""
+    original = logger.level
+    yield
+    logger.setLevel(original)
+
+
 def test_progress_enabled_for_interactive_info_output(monkeypatch) -> None:
     """Interactive INFO output keeps progress bars enabled."""
-    original_level = logger.level
     monkeypatch.delenv('CI', raising=False)
     logger.setLevel(Level.INFO.value)
-    try:
-        assert should_disable_progress(stream=_Stream(True)) is False
-    finally:
-        logger.setLevel(original_level)
+
+    assert should_disable_progress(stream=_Stream(is_tty=True)) is False
 
 
 def test_progress_disabled_for_non_tty_output(monkeypatch) -> None:
     """Piped or redirected output disables animated progress bars."""
-    original_level = logger.level
     monkeypatch.delenv('CI', raising=False)
     logger.setLevel(Level.INFO.value)
-    try:
-        assert should_disable_progress(stream=_Stream(False)) is True
-    finally:
-        logger.setLevel(original_level)
+
+    assert should_disable_progress(stream=_Stream(is_tty=False)) is True
 
 
 def test_progress_disabled_for_debug_logging(monkeypatch) -> None:
-    """Debug logs stay free of tqdm carriage-return output."""
-    original_level = logger.level
+    """Debug logs stay free of tqdm carriage-return output, even on a TTY."""
     monkeypatch.delenv('CI', raising=False)
     logger.setLevel(Level.DEBUG.value)
-    try:
-        assert should_disable_progress(stream=_Stream(True)) is True
-    finally:
-        logger.setLevel(original_level)
+
+    assert should_disable_progress(stream=_Stream(is_tty=True)) is True
 
 
 def test_progress_disabled_in_ci(monkeypatch) -> None:
-    """CI logs suppress animated progress even if stdout reports as a TTY."""
-    original_level = logger.level
+    """CI logs suppress animated progress even if the stream reports as a TTY."""
     monkeypatch.setenv('CI', 'true')
     logger.setLevel(Level.INFO.value)
-    try:
-        assert should_disable_progress(stream=_Stream(True)) is True
-    finally:
-        logger.setLevel(original_level)
+
+    assert should_disable_progress(stream=_Stream(is_tty=True)) is True
+
+
+@pytest.mark.parametrize('ci_value', ['', '0', 'false', 'no', 'off', 'False', ' OFF '])
+def test_progress_not_forced_by_falsey_ci_values(monkeypatch, ci_value: str) -> None:
+    """A falsey CI value must not force-hide an otherwise interactive bar."""
+    monkeypatch.setenv('CI', ci_value)
+    logger.setLevel(Level.INFO.value)
+
+    assert should_disable_progress(stream=_Stream(is_tty=True)) is False
+
+
+def test_progress_default_stream_follows_stderr(monkeypatch) -> None:
+    """tqdm writes to stderr, so a non-TTY stderr hides the bar even when stdout is a TTY."""
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.INFO.value)
+    monkeypatch.setattr(sys, 'stderr', _Stream(is_tty=False))
+    monkeypatch.setattr(sys, 'stdout', _Stream(is_tty=True))
+
+    assert should_disable_progress() is True
+
+
+def test_progress_default_stream_ignores_redirected_stdout(monkeypatch) -> None:
+    """A redirected stdout must not hide a bar that still renders on an interactive stderr."""
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.INFO.value)
+    monkeypatch.setattr(sys, 'stderr', _Stream(is_tty=True))
+    monkeypatch.setattr(sys, 'stdout', _Stream(is_tty=False))
+
+    assert should_disable_progress() is False

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÜ
+
+"""Tests for logging helpers."""
+
+from collider.log import Level, logger, should_disable_progress
+
+
+class _Stream:
+    """Small stream stub for progress output detection tests."""
+
+    def __init__(self, is_tty: bool):
+        self._is_tty = is_tty
+
+    def isatty(self) -> bool:
+        return self._is_tty
+
+
+def test_progress_enabled_for_interactive_info_output(monkeypatch) -> None:
+    """Interactive INFO output keeps progress bars enabled."""
+    original_level = logger.level
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.INFO.value)
+    try:
+        assert should_disable_progress(stream=_Stream(True)) is False
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_progress_disabled_for_non_tty_output(monkeypatch) -> None:
+    """Piped or redirected output disables animated progress bars."""
+    original_level = logger.level
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.INFO.value)
+    try:
+        assert should_disable_progress(stream=_Stream(False)) is True
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_progress_disabled_for_debug_logging(monkeypatch) -> None:
+    """Debug logs stay free of tqdm carriage-return output."""
+    original_level = logger.level
+    monkeypatch.delenv('CI', raising=False)
+    logger.setLevel(Level.DEBUG.value)
+    try:
+        assert should_disable_progress(stream=_Stream(True)) is True
+    finally:
+        logger.setLevel(original_level)
+
+
+def test_progress_disabled_in_ci(monkeypatch) -> None:
+    """CI logs suppress animated progress even if stdout reports as a TTY."""
+    original_level = logger.level
+    monkeypatch.setenv('CI', 'true')
+    logger.setLevel(Level.INFO.value)
+    try:
+        assert should_disable_progress(stream=_Stream(True)) is True
+    finally:
+        logger.setLevel(original_level)

--- a/test/utils/packaging/test_resolver.py
+++ b/test/utils/packaging/test_resolver.py
@@ -23,6 +23,7 @@ from collider.utils.packaging.resolver import (
     RootSpec,
     _filter_satisfied_skips,
     _group_by_package,
+    _ProgressReporter,
     build_dep_name_index,
     resolve_all_dependencies,
     resolve_dependencies,
@@ -1612,3 +1613,26 @@ def test_resolve_dependencies_filters_satisfied_skips() -> None:
     assert 'abseil-cpp' in result.mapping
     assert result.summary.skipped_conditional == set()
     assert result.summary.skipped_conditional_by_pkg == {}
+
+
+@pytest.mark.parametrize('disable', [True, False])
+def test_progress_reporter_forwards_disable_to_tqdm(disable: bool) -> None:
+    """The resolution progress bar is created with the disable flag it was given."""
+    with patch('collider.utils.packaging.resolver.tqdm') as mock_tqdm:
+        _ProgressReporter(disable=disable).starting()
+
+    assert mock_tqdm.call_args.kwargs['disable'] is disable
+
+
+def test_resolve_dependencies_disables_progress_via_helper() -> None:
+    """resolve_dependencies wires should_disable_progress into the progress bar."""
+    repos: dict = {}
+    with (
+        patch('collider.utils.packaging.resolver.should_disable_progress', return_value=True),
+        patch('collider.utils.packaging.resolver._ProgressReporter') as mock_reporter,
+        patch.object(resolvelib.Resolver, 'resolve', side_effect=RuntimeError('stop')),
+    ):
+        with pytest.raises(RuntimeError, match='stop'):
+            resolve_dependencies('grpc', None, repos)
+
+    assert mock_reporter.call_args.kwargs['disable'] is True


### PR DESCRIPTION
Fixes #47. Supersedes #50 and #48.

## What

Progress bars (tqdm) were emitted even when output was non-interactive, cluttering captured logs with carriage-return spam. This adds a shared `should_disable_progress()` helper and applies it at the three tqdm call sites (the two `resolve_*` paths and the transitive install loop), hiding bars under debug logging, under CI, or when the output stream is not a TTY.

## Credit

This PR is built from two community contributions:

- **#50 by @hass-nation** -- the base implementation (the `should_disable_progress()` bool helper, robust `CI` parsing, and the call-site wiring). Their commit is included in this branch.
- **#48 by @Dylan-Geraci** -- independently identified the key correctness point: tqdm writes to **stderr** by default, so that is the stream whose interactivity must be checked. Credited as co-author on the fix commit.

## The fix on top of #50

#50 probed `sys.stdout`, but the bars render on tqdm's default stream, **stderr**. That mismatch left the bug half-fixed:

- `collider ... 2> log.txt` (stderr piped, stdout still a TTY): #50 saw stdout was a TTY and left the bar spewing carriage returns into `log.txt` -- the exact bug.
- `collider ... > log.txt` (stdout piped, stderr a terminal): #50 hid a bar that would have rendered fine on the terminal.

The fix probes **stderr** by default, so interactivity is judged on the stream the bar actually uses.

## Tests

- Helper: interactive / non-TTY / debug / CI, plus parametrized falsey-`CI` values (`''`, `0`, `false`, `no`, `off`, ...), and two regression tests pinning the default-stream-follows-stderr behavior (these fail against the original `sys.stdout` check).
- Wiring: `_ProgressReporter` forwards the `disable` flag onto the tqdm bar, and `resolve_dependencies` routes `should_disable_progress()` into the reporter.

`pytest` 759 passed / 1 skipped; `ruff format`, `ruff check`, `ty`, `pylint` (10/10) all clean.