### PR TITLE
project_state: narrow lockfile read diagnostics

### DIFF
--- a/collider/subcommand/pkg/Prune.py
+++ b/collider/subcommand/pkg/Prune.py
@@ -28,6 +28,7 @@ from collider.utils.packaging.resolver import (
 )
 from collider.utils.project_state import (
     load_colliderfile,
+    read_lockfile,
     remove_installed_artifacts,
     scan_wraps,
 )
@@ -103,10 +104,8 @@ def run_prune(context: Context, dry_run: bool = False) -> int:
         )
         return os.EX_OK
 
-    try:
-        lockfile = Lockfile.from_path(lockfile_path)
-    except Exception:
-        logger.warning('collider.lock could not be read. Run "collider lock" to regenerate it.')
+    lockfile = read_lockfile(lockfile_path)
+    if lockfile is None:
         return os.EX_OK
 
     managed = set(lockfile.all_packages.keys())

--- a/collider/subcommand/pkg/Remove.py
+++ b/collider/subcommand/pkg/Remove.py
@@ -31,6 +31,7 @@ from collider.utils.packaging.resolver import (
 from collider.utils.project_state import (
     find_collider_dependency,
     load_colliderfile,
+    read_lockfile,
     remove_collider_dependency,
     remove_installed_artifacts,
     scan_wraps,
@@ -236,9 +237,8 @@ class Remove(SubcommandInterface):
             )
             return
 
-        try:
-            lockfile = Lockfile.from_path(lockfile_path)
-        except Exception:
+        lockfile = read_lockfile(lockfile_path)
+        if lockfile is None:
             logger.info(
                 'Additional wraps remain in subprojects/. Collider cannot safely '
                 'determine which are orphaned without existing ownership metadata. '

--- a/collider/subcommand/pkg/Remove.py
+++ b/collider/subcommand/pkg/Remove.py
@@ -88,6 +88,9 @@ class Remove(SubcommandInterface):
         if not validate_meson_project_cwd():
             return os.EX_NOINPUT
 
+        lockfile_path = Path.cwd() / Lockfile.get_filename()
+        prune_was_skipped = self.prune and not lockfile_path.exists()
+
         colliderfile = load_colliderfile()
         if find_collider_dependency(colliderfile, self.package_name) is None:
             logger.critical(
@@ -133,6 +136,10 @@ class Remove(SubcommandInterface):
             )
 
         warn_if_lockfile_needs_refresh(self.package_name)
+        if prune_was_skipped:
+            logger.info(
+                'prune skipped: no lockfile; run "collider lock" to create ownership metadata.'
+            )
         return os.EX_OK
 
     def _resolve_remaining_needed_packages(self, colliderfile: Colliderfile) -> Optional[set[str]]:

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 
 from pathlib import Path
@@ -20,6 +21,28 @@ from collider.utils.packaging.Dependency import Dependency, DependencySource
 def load_colliderfile() -> Colliderfile:
     """Load collider.json from the current project root."""
     return Colliderfile.from_path(Path.cwd() / Colliderfile.get_filename())
+
+
+def read_lockfile(lockfile_path: Path, *, warn_on_error: bool = True) -> Optional[Lockfile]:
+    """
+    Read collider.lock with explicit diagnostics for parse and IO failures.
+    :param lockfile_path: Path to collider.lock.
+    :param warn_on_error: When True, log a warning before returning None.
+    :return: Loaded lockfile, or None when the file is missing or unreadable.
+    """
+    try:
+        with open(lockfile_path, 'r', encoding='UTF-8') as lockfile_stream:
+            return Lockfile.from_stream(lockfile_stream)
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        if warn_on_error:
+            logger.warning('collider.lock could not be read. Run "collider lock" to regenerate it.')
+    except OSError as exc:
+        if warn_on_error:
+            logger.warning(
+                f'Could not read collider.lock: {exc}. Run "collider lock" to regenerate it.'
+            )
+
+    return None
 
 
 def find_collider_dependency(colliderfile: Colliderfile, package_name: str) -> Optional[Dependency]:
@@ -90,9 +113,8 @@ def warn_if_lockfile_needs_refresh(package_name: str) -> None:
     if not lockfile_path.exists():
         return
 
-    try:
-        lockfile = Lockfile.from_path(lockfile_path)
-    except Exception:
+    lockfile = read_lockfile(lockfile_path, warn_on_error=False)
+    if lockfile is None:
         return
 
     if package_name in lockfile.all_packages:

--- a/test/common/fixture.py
+++ b/test/common/fixture.py
@@ -13,6 +13,22 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 
+for name, value in {
+    'EX_OK': 0,
+    'EX_USAGE': 64,
+    'EX_DATAERR': 65,
+    'EX_NOINPUT': 66,
+    'EX_UNAVAILABLE': 69,
+    'EX_IOERR': 74,
+    'EX_CANTCREAT': 73,
+    'EX_CONFIG': 78,
+    'EX_NOPERM': 77,
+    'EX_SOFTWARE': 70,
+}.items():
+    if not hasattr(os, name):
+        setattr(os, name, value)
+
+
 MESON_PROJECTS = ['header', 'none', 'shared']
 
 

--- a/test/subcommand/test_remove.py
+++ b/test/subcommand/test_remove.py
@@ -634,6 +634,37 @@ def test_remove_with_prune_warns_on_corrupt_lockfile(
     assert 'could not be read' in caplog.text
 
 
+def test_remove_with_prune_summarizes_when_lockfile_is_missing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """--prune ends with a clear skipped-prune summary when there is no lockfile."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('grpc', DependencySource.COLLIDER, None)],
+    )
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir()
+    (subprojects / 'grpc.wrap').write_text('[wrap-file]\n', encoding='utf-8')
+    (subprojects / 'abseil-cpp.wrap').write_text('[wrap-file]\n', encoding='utf-8')
+
+    context = _make_context(tmp_path)
+    cmd = Remove(argparse.Namespace(package='grpc', prune=True), context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)
+
+    assert not (subprojects / 'grpc.wrap').exists()
+    assert (subprojects / 'abseil-cpp.wrap').exists()
+    assert 'No lockfile found' in caplog.text
+    assert 'prune skipped: no lockfile; run "collider lock" to create ownership metadata.' in (
+        caplog.text
+    )
+
+
 def test_remove_keeps_artifacts_when_dependency_index_is_unavailable(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/test/utils/test_project_state.py
+++ b/test/utils/test_project_state.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 MOG Robotics OÃœ
+
+"""Test project-state helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.utils.project_state import read_lockfile
+
+
+def test_read_lockfile_loads_valid_file(tmp_path: Path) -> None:
+    """A valid collider.lock is parsed and returned."""
+    lockfile = Lockfile(
+        dependencies={
+            'shared': LockedPackage(
+                version='1.0.0',
+                wrap_hash='sha256:' + 'a' * 64,
+                origin='https://wrapdb.example.com/v2/',
+            ),
+        }
+    )
+    lockfile_path = tmp_path / Lockfile.get_filename()
+    lockfile.save(lockfile_path)
+
+    loaded = read_lockfile(lockfile_path)
+
+    assert loaded is not None
+    assert 'shared' in loaded.all_packages
+
+
+def test_read_lockfile_warns_on_corrupt_json(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Malformed JSON is reported with a lockfile-specific warning."""
+    lockfile_path = tmp_path / Lockfile.get_filename()
+    lockfile_path.write_text('not valid json{{{{', encoding='utf-8')
+
+    loaded = read_lockfile(lockfile_path)
+
+    assert loaded is None
+    assert 'collider.lock could not be read' in caplog.text
+
+
+def test_read_lockfile_warns_on_oserror(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """OS-level read failures are reported with a distinct warning."""
+    lockfile_path = tmp_path / Lockfile.get_filename()
+    lockfile_path.mkdir()
+
+    loaded = read_lockfile(lockfile_path)
+
+    assert loaded is None
+    assert 'Could not read collider.lock' in caplog.text


### PR DESCRIPTION
Add a shared lockfile reader with explicit parse/IO diagnostics, route prune/remove through it, and keep the refresh warning path from swallowing unreadable lockfiles silently. This tightens the project-state error handling without changing the existing fail-closed behavior.