### PR TITLE
fix(docs): add stable /latest/ alias and update README links

### DIFF
--- a/.ci/update-site-root.sh
+++ b/.ci/update-site-root.sh
@@ -85,3 +85,13 @@ EOF
 if [[ -n "$latest" && -f "$WEB_ROOT/$latest/404.html" ]]; then
   cp "$WEB_ROOT/$latest/404.html" "$WEB_ROOT/404.html"
 fi
+
+# Maintain a stable /latest/ alias pointing at the newest release so external links (README, etc.)
+# never go stale across releases. It serves the same pages as /<latest>/, whose canonical URLs point
+# back at the versioned path, so search engines consolidate there. The scan above ignores it (not a
+# semver dir, not the dev dir), so it never appears as a version.
+if [[ -n "$latest" ]]; then
+  ln -sfn "$latest" "$WEB_ROOT/latest"
+else
+  rm -f "$WEB_ROOT/latest"
+fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://collider.ee/assets/logo.svg" width="300">
+<img src="https://collider.ee/latest/assets/logo.svg" width="300">
 </p>
 
 <p align="center">
@@ -77,18 +77,18 @@ collider setup                                                  # configure the 
 collider lock                                                   # write collider.lock for reproducible installs
 ```
 
-See the [Quick Start guide](https://collider.ee/getting-started/quickstart/) for
+See the [Quick Start guide](https://collider.ee/latest/getting-started/quickstart/) for
 a full walkthrough.
 
 ## Documentation
 
 Full documentation lives at [collider.ee](https://collider.ee):
 
-- [Getting started](https://collider.ee/getting-started/quickstart/): install and first steps.
-- [User guide](https://collider.ee/guide/project-setup/): managing packages, repositories, publishing, locking, offline mode, and serving.
-- [Configuration](https://collider.ee/reference/configuration/): `config.json`, `collider.json`, and `collider.lock`.
-- [CLI reference](https://collider.ee/reference/cli/): every command, flag, and exit code.
-- [Contributing](https://collider.ee/development/contributing/): development setup and pull request checks.
+- [Getting started](https://collider.ee/latest/getting-started/quickstart/): install and first steps.
+- [User guide](https://collider.ee/latest/guide/project-setup/): managing packages, repositories, publishing, locking, offline mode, and serving.
+- [Configuration](https://collider.ee/latest/reference/configuration/): `config.json`, `collider.json`, and `collider.lock`.
+- [CLI reference](https://collider.ee/latest/reference/cli/): every command, flag, and exit code.
+- [Contributing](https://collider.ee/latest/development/contributing/): development setup and pull request checks.
 
 ## License
 


### PR DESCRIPTION
The README linked to the old flat doc paths (`/getting-started/quickstart/`, `/guide/project-setup/`, the root `/assets/logo.svg`, ...), which 404 under the versioned layout.

- `update-site-root.sh` now maintains a `/latest/` symlink to the newest release on every deploy, so external links never go stale across releases. The scan ignores it (not a semver/dev dir), and each page's canonical still points at the versioned path so search consolidates there.
- README links repointed to `https://collider.ee/latest/...` (the bare homepage links are left as-is since `/` already redirects to latest).

Verified all README URLs return 200 live.