### PR TITLE
chore(contributing): add CONTRIBUTING, AI disclosure and DCO checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,12 @@ Brief description of the change.
 
 ## Checklist
 
-- [ ] Tests pass locally (e.g. `uv run pytest`)
-- [ ] Code follows project style (e.g. `uv run ruff check .`)
+- [ ] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
+- [ ] My commits are signed off (`git commit -s`) per the DCO.
+- [ ] Tests pass locally (e.g. `uv run pytest`).
+- [ ] Code follows project style (e.g. `uv run ruff check .`).
+
+## AI disclosure
+
+- [ ] AI tools were used for part or all of this change.
+- [ ] If AI was used: I have personally reviewed every line, understand it, and take full responsibility for what is submitted.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@ Brief description of the change.
 ## AI disclosure
 
 - [ ] AI tools were used for part or all of this change.
-  - [ ] A **human** -- not an AI agent -- has reviewed every line, understands the change, and takes full responsibility for what is submitted.
+  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@ Brief description of the change.
 ## AI disclosure
 
 - [ ] AI tools were used for part or all of this change.
-- [ ] If AI was used: I have personally reviewed every line, understand it, and take full responsibility for what is submitted.
+  - [ ] A **human** -- not an AI agent -- has reviewed every line, understands the change, and takes full responsibility for what is submitted.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,9 @@ Brief description of the change.
 
 - [ ] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
 - [ ] My commits are signed off (`git commit -s`) per the DCO.
-- [ ] Tests pass locally (e.g. `uv run pytest`).
-- [ ] Code follows project style (e.g. `uv run ruff check .`).
+- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+- [ ] Tests pass (`uv run pytest`).
+- [ ] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).
 
 ## AI disclosure
 

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,42 @@
+name: dco
+
+# Enforce the Developer Certificate of Origin: every commit in the PR must be signed off
+# (git commit -s adds a "Signed-off-by: Name <email>" trailer).
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    if: ${{ github.actor != 'nektos/act' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for sha in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
+            subject=$(git show -s --format='%s' "$sha")
+            signoff=$(git show -s --format='%(trailers:key=Signed-off-by,valueonly)' "$sha")
+            if printf '%s' "$signoff" | grep -qE '.+ <[^@[:space:]]+@[^>[:space:]]+>'; then
+              echo "OK   $sha $subject"
+            else
+              echo "::error::Commit is not signed off: $sha $subject"
+              fail=1
+            fi
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "::error::All commits must be signed off. Use 'git commit -s' (see CONTRIBUTING.md)."
+          fi
+          exit "$fail"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -25,8 +25,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # Resolve the range fail-closed: a bad range must error, never silently check zero commits.
+          base=$(git merge-base "$BASE_SHA" "$HEAD_SHA") \
+            || { echo "::error::Could not find the merge base of $BASE_SHA and $HEAD_SHA."; exit 1; }
+          # Scope to the PR's own commits from the merge base, and skip merge commits (e.g. merging
+          # the base branch in) which legitimately carry no sign-off.
+          commits=$(git rev-list --no-merges "$base..$HEAD_SHA") \
+            || { echo "::error::Could not list commits in $base..$HEAD_SHA."; exit 1; }
           fail=0
-          for sha in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
+          for sha in $commits; do
             subject=$(git show -s --format='%s' "$sha")
             signoff=$(git show -s --format='%(trailers:key=Signed-off-by,valueonly)' "$sha")
             if printf '%s' "$signoff" | grep -qE '.+ <[^@[:space:]]+@[^>[:space:]]+>'; then

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -19,8 +19,9 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -uo pipefail
-          # True when a TICKED checkbox line contains the given phrase (case-insensitive).
-          checked() { printf '%s\n' "$PR_BODY" | grep -iE '^[[:space:]]*-[[:space:]]*\[[xX]\]' | grep -qi "$1"; }
+          # The phrases below must match the checkbox text in .github/PULL_REQUEST_TEMPLATE.md.
+          # True when a TICKED checkbox line (- or * bullet) contains the given phrase (case-insensitive).
+          checked() { printf '%s\n' "$PR_BODY" | grep -iE '^[[:space:]]*[-*][[:space:]]*\[[xX]\]' | grep -qi "$1"; }
           fail=0
 
           if checked "contributing guidelines"; then

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,47 @@
+name: pr-checklist
+
+# Soft barrier: confirm the PR template's required boxes are ticked. Re-runs when the description
+# is edited so ticking a box clears the check. Maintainers can still override by editing the boxes.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  checklist:
+    if: ${{ github.actor != 'nektos/act' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify checklist and AI disclosure
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -uo pipefail
+          # True when a TICKED checkbox line contains the given phrase (case-insensitive).
+          checked() { printf '%s\n' "$PR_BODY" | grep -iE '^[[:space:]]*-[[:space:]]*\[[xX]\]' | grep -qi "$1"; }
+          fail=0
+
+          if checked "contributing guidelines"; then
+            echo "OK: contributing guidelines acknowledged."
+          else
+            echo "::error::Please tick the box confirming you have read the contributing guidelines."
+            fail=1
+          fi
+
+          # The disclosure is honor-system; but if AI use IS disclosed, the human-responsibility
+          # attestation becomes mandatory.
+          if checked "AI tools were used"; then
+            echo "AI use disclosed."
+            if checked "full responsibility"; then
+              echo "OK: human review and responsibility attested."
+            else
+              echo "::error::You disclosed AI use -- also tick the box confirming a human reviewed every line and takes full responsibility."
+              fail=1
+            fi
+          else
+            echo "No AI use disclosed."
+          fi
+
+          exit "$fail"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ time focused on genuine contributions:
 
 - **Disclose** in the pull request whether AI tools were used for any part of the
   change.
-- If AI was used, a **human must fully review every line**, understand it, and take
-  **full responsibility** for its correctness, security, and quality -- the same as
-  if it had been written by hand.
+- If AI was used, a **human -- not the AI agent that produced the change -- must
+  review every line**, understand it, and take **full responsibility** for its
+  correctness, security, and quality, the same as if it had been written by hand.
 - Pull requests that appear to be unreviewed machine output, or that do not disclose
   AI use, may be closed without further review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to Collider
+
+Thanks for taking the time to contribute. This page covers how to propose changes
+responsibly. For the development environment, running tests, code style, and the
+commit convention, see the
+[development guide](https://collider.ee/latest/development/contributing/).
+
+## Reporting issues
+
+Open a [bug report or feature request](https://github.com/MaxandreOgeret/collider/issues/new/choose)
+and include enough detail to reproduce the problem or understand the request.
+
+## Pull requests
+
+- Branch from and open pull requests against `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/)
+  (`type(scope): description`); the commit linter and the full CI suite
+  (pytest 3.10-3.13, ruff, ty, pylint) must pass.
+- Keep each pull request focused, and explain the *why* in the description.
+- Fill in the pull request template, including the checklist and the AI
+  disclosure.
+
+## Signing off your commits (DCO)
+
+Collider uses the [Developer Certificate of Origin](https://developercertificate.org/):
+every commit must carry a `Signed-off-by` line certifying that you wrote the change,
+or otherwise have the right to submit it under the project's license. Add it with:
+
+```bash
+git commit -s -m "feat(scope): ..."
+```
+
+This appends `Signed-off-by: Your Name <your@email>` from your git `user.name` and
+`user.email`. CI rejects pull requests whose commits are not signed off. To sign off
+commits you have already made, run `git rebase --signoff <base-branch>` and
+force-push the branch.
+
+## Use of AI tools
+
+AI assistance is allowed, but accountability is not optional. This project has
+received unsolicited, low-effort, machine-generated pull requests; to keep review
+time focused on genuine contributions:
+
+- **Disclose** in the pull request whether AI tools were used for any part of the
+  change.
+- If AI was used, a **human must fully review every line**, understand it, and take
+  **full responsibility** for its correctness, security, and quality -- the same as
+  if it had been written by hand.
+- Pull requests that appear to be unreviewed machine output, or that do not disclose
+  AI use, may be closed without further review.
+
+By opening a pull request you confirm the submission is your own work (or is properly
+attributed) and that you stand behind it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ time focused on genuine contributions:
 
 - **Disclose** in the pull request whether AI tools were used for any part of the
   change.
-- If AI was used, a **human -- not the AI agent that produced the change -- must
-  review every line**, understand it, and take **full responsibility** for its
-  correctness, security, and quality, the same as if it had been written by hand.
+- If AI was used, a **human (not the AI agent that produced the change) must review
+  every line**, understand it, and take **full responsibility** for its correctness,
+  security, and quality, the same as if it had been written by hand.
 - Pull requests that appear to be unreviewed machine output, or that do not disclose
   AI use, may be closed without further review.
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -63,7 +63,26 @@ fix(serve): log warning on non-loopback push endpoint
 docs(contributing): add local dev setup guide
 ```
 
+## Sign Off Your Commits
+
+Collider uses the [Developer Certificate of Origin](https://developercertificate.org/).
+Every commit must carry a `Signed-off-by` line certifying you have the right to submit
+the change. Add it with:
+
+```bash
+git commit -s -m "feat(scope): ..."
+```
+
+CI rejects pull requests with unsigned commits. To sign off commits you have already
+made, run `git rebase --signoff <base-branch>` and force-push.
+
 ## Pull Requests
 
-Open pull requests against `main`. CI runs pytest on Python 3.10 through 3.13,
-and ruff, ty, and pylint on Python 3.13. All checks must pass before merge.
+Open pull requests against `main` and fill in the pull request template, including the
+checklist and the AI-use disclosure. CI runs pytest on Python 3.10 through 3.13; ruff,
+ty, and pylint on Python 3.13; Conventional Commit and sign-off (DCO) checks; and the
+template checklist. All checks must pass before merge.
+
+If you used AI tools for any part of a change, you must disclose it and confirm that a
+human (not the AI) reviewed every line and takes full responsibility. See the full
+[contribution guidelines and AI policy](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Adds a soft barrier against drive-by / undisclosed AI pull requests:

- Root **`CONTRIBUTING.md`** (GitHub-recognized) with the PR process, an **AI-use disclosure policy**, and **DCO sign-off**. Dev-setup mechanics stay in the docs guide (linked, no duplication).
- PR template gains: read-guidelines box, signed-off reminder, and the **AI disclosure + human-responsibility** boxes.
- **`pr-checklist`** workflow: requires the guidelines box, and (conditionally) the responsibility box when AI use is disclosed.
- **`dco`** workflow: every commit must be signed off (`git commit -s`).

These are intentionally *soft* (maintainers can override), but the two checks give a real, documented basis to close non-compliant PRs.

## Type of change

- [x] Other (contribution policy / CI)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the DCO.
- [x] Tests pass locally (e.g. `uv run pytest`).
- [x] Code follows project style (e.g. `uv run ruff check .`).

## AI disclosure

- [x] AI tools were used for part or all of this change.
- [x] If AI was used: I have personally reviewed every line, understand it, and take full responsibility for what is submitted.