### PR TITLE
docs(contributing): drop the grievance clause from the AI policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,7 @@ and include enough detail to reproduce the problem or understand the request.
 
 ## Use of AI tools
 
-AI assistance is allowed, but accountability is not optional. This project has
-received unsolicited, low-effort, machine-generated pull requests; to keep review
-time focused on genuine contributions:
+AI assistance is allowed, but accountability is not optional:
 
 - **Disclose** in the pull request whether AI tools were used for any part of the
   change.


### PR DESCRIPTION
Removes the "this project has received unsolicited, low-effort, machine-generated pull requests" clause from the AI-use policy. The policy reads cleaner just stating the requirement.

## Type of change

- [x] Documentation

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass.

## AI disclosure

- [ ] AI tools were used for part or all of this change.
  - [ ] A human (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.