### PR TITLE
feat(publish): require https for token push, add --insecure override

### DIFF
--- a/collider/subcommand/Publish.py
+++ b/collider/subcommand/Publish.py
@@ -30,7 +30,7 @@ from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
 from collider.utils.meson.info import load_project_metadata
 from collider.utils.meson.meson import DEFAULT_BUILD_DIR
-from collider.utils.network import DEFAULT_NETWORK_TIMEOUT, safe_urlopen
+from collider.utils.network import DEFAULT_NETWORK_TIMEOUT, may_send_push_token, safe_urlopen
 from collider.utils.packaging import compute_file_hash
 
 
@@ -80,6 +80,12 @@ class Publish(SubcommandInterface):
             help='Environment variable to read push token from for collider repositories.',
         )
         parser.add_argument(
+            '--insecure',
+            action='store_true',
+            default=False,
+            help='Allow pushing to a non-https repository, sending the token in cleartext.',
+        )
+        parser.add_argument(
             '--dry-run',
             action='store_true',
             default=False,
@@ -97,6 +103,7 @@ class Publish(SubcommandInterface):
         self.builddir: Path = args.builddir
         self.patch_archive: Path | None = args.patch_archive
         self.push_token_env: str = args.push_token_env
+        self.insecure: bool = getattr(args, 'insecure', False)
         self.dry_run: bool = args.dry_run
 
     @override
@@ -180,13 +187,9 @@ class Publish(SubcommandInterface):
                         repo.url.geturl(),
                     )
                 else:
-                    push_token = self._load_remote_push_token()
-                    if push_token is None:
-                        return os.EX_USAGE
-                    payload = self._build_remote_push_payload(
-                        package, source_archive, self.patch_archive
-                    )
-                    self._push_remote_wrap_repo(repo, push_token, payload)
+                    result = self._push_to_remote_collider(repo, package, source_archive)
+                    if result != os.EX_OK:
+                        return result
         except PackageAlreadyExistsError:
             logger.critical(
                 f'Version "{version}" of "{package_name}" already exists in repository '
@@ -203,6 +206,25 @@ class Publish(SubcommandInterface):
 
         if not self.dry_run:
             logger.info(f'Package "{package.name}" published successfully.')
+        return os.EX_OK
+
+    def _push_to_remote_collider(
+        self, repo: Collider, package: WrapPackage, source_archive: Path
+    ) -> int:
+        """
+        Send a built package to a remote collider repository, refusing an insecure transport.
+        :param repo: Target collider repository.
+        :param package: Built wrap package to publish.
+        :param source_archive: Source archive to upload.
+        :return: os.EX_OK on success, or an error code when the push is refused.
+        """
+        push_token = self._load_remote_push_token()
+        if push_token is None:
+            return os.EX_USAGE
+        if not may_send_push_token(repo.url, insecure=self.insecure):
+            return os.EX_USAGE
+        payload = self._build_remote_push_payload(package, source_archive, self.patch_archive)
+        self._push_remote_wrap_repo(repo, push_token, payload)
         return os.EX_OK
 
     @staticmethod

--- a/collider/subcommand/Unpublish.py
+++ b/collider/subcommand/Unpublish.py
@@ -18,7 +18,7 @@ from collider.repository.implementation.Filesystem import Filesystem
 from collider.repository.implementation.Wrap import Wrap
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
-from collider.utils.network import DEFAULT_NETWORK_TIMEOUT, safe_urlopen
+from collider.utils.network import DEFAULT_NETWORK_TIMEOUT, may_send_push_token, safe_urlopen
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
 
@@ -73,6 +73,12 @@ class Unpublish(SubcommandInterface):
             default=_DEFAULT_PUSH_TOKEN_ENV,
             help='Environment variable to read push token from for collider repositories.',
         )
+        parser.add_argument(
+            '--insecure',
+            action='store_true',
+            default=False,
+            help='Allow deleting from a non-https repository, sending the token in cleartext.',
+        )
 
     def __init__(self, args: argparse.Namespace, context: Context):
         """
@@ -85,6 +91,7 @@ class Unpublish(SubcommandInterface):
         self.package_name: str = args.package
         self.version: str = args.version
         self.push_token_env: str = args.push_token_env
+        self.insecure: bool = getattr(args, 'insecure', False)
 
     @override
     def execute(self) -> int:
@@ -178,6 +185,9 @@ class Unpublish(SubcommandInterface):
                 f'Deleting from collider repository requires bearer token in "{self.push_token_env}". '
                 f'Export it first, e.g. `export {self.push_token_env}=<token>`.'
             )
+            return os.EX_USAGE
+
+        if not may_send_push_token(repo.url, insecure=self.insecure):
             return os.EX_USAGE
 
         repo_key = make_repo_key(self.package_name, self.version, PackageType.WRAP)

--- a/collider/utils/network.py
+++ b/collider/utils/network.py
@@ -6,6 +6,8 @@
 import urllib.parse
 import urllib.request
 
+from collider.log import logger
+
 
 DEFAULT_NETWORK_TIMEOUT = 30.0
 
@@ -44,3 +46,28 @@ def build_safe_opener() -> urllib.request.OpenerDirector:
 def safe_urlopen(request, *, timeout: float = DEFAULT_NETWORK_TIMEOUT):
     """Open a request through the cross-origin credential-stripping opener."""
     return build_safe_opener().open(request, timeout=timeout)
+
+
+def may_send_push_token(url: urllib.parse.ParseResult, *, insecure: bool) -> bool:
+    """
+    Decide whether a bearer-token push may be sent to the given URL.
+    Sending the credential over a non-HTTPS transport exposes it in cleartext, so a non-HTTPS push
+    is refused unless the caller explicitly opts in with insecure.
+    :param url: Parsed push or delete endpoint URL.
+    :param insecure: Allow sending the token over a non-HTTPS connection.
+    :return: True when the push may proceed, False when it must be refused.
+    """
+    scheme = url.scheme.lower()
+    if scheme == 'https':
+        return True
+    if insecure:
+        logger.warning(
+            f'Sending the push token over an insecure "{scheme}" connection because --insecure '
+            'was passed.'
+        )
+        return True
+    logger.critical(
+        f'Refusing to send the push token over an insecure "{scheme}" connection. Use an https '
+        'repository URL, or pass --insecure to send the token in cleartext.'
+    )
+    return False

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -135,7 +135,7 @@ Generate a wrap and source archive, then publish to a repository.
 
 ```bash
 collider publish <repo> [--builddir PATH] [--patch-archive PATH]
-                        [--push-token-env VAR] [--dry-run]
+                        [--push-token-env VAR] [--insecure] [--dry-run]
 ```
 
 | Option                | Description                                              |
@@ -144,6 +144,7 @@ collider publish <repo> [--builddir PATH] [--patch-archive PATH]
 | `--builddir PATH`     | Meson build directory (default: `collider-build`).       |
 | `--patch-archive PATH`| Attach a patch archive to the published package.         |
 | `--push-token-env VAR`| Environment variable holding the bearer token (default: `COLLIDER_PUSH_TOKEN`). |
+| `--insecure`          | Allow pushing to a non-`https` repository, sending the token in cleartext. |
 | `--dry-run`           | Validate and package without writing to the repository.  |
 
 ---
@@ -153,7 +154,7 @@ collider publish <repo> [--builddir PATH] [--patch-archive PATH]
 Remove a package version from a repository.
 
 ```bash
-collider unpublish <repo> <package> <version> [--push-token-env VAR]
+collider unpublish <repo> <package> <version> [--push-token-env VAR] [--insecure]
 ```
 
 | Option                | Description                                              |
@@ -162,6 +163,7 @@ collider unpublish <repo> <package> <version> [--push-token-env VAR]
 | `<package>`           | Package name.                                            |
 | `<version>`           | Version to remove.                                       |
 | `--push-token-env VAR`| Environment variable holding the bearer token.           |
+| `--insecure`          | Allow deleting from a non-`https` repository, sending the token in cleartext. |
 
 ---
 

--- a/test/contract/test_publish_exit_codes.py
+++ b/test/contract/test_publish_exit_codes.py
@@ -65,6 +65,7 @@ def _push_args(
     patch_archive: Path | None = None,
     push_token_env: str = 'COLLIDER_PUSH_TOKEN',
     dry_run: bool = False,
+    insecure: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         repository=repository,
@@ -72,6 +73,7 @@ def _push_args(
         patch_archive=patch_archive,
         push_token_env=push_token_env,
         dry_run=dry_run,
+        insecure=insecure,
     )
 
 
@@ -158,7 +160,8 @@ def test_publish_ex_ioerr_unreachable_endpoint(tmp_path: Path) -> None:
     closed_port = _unused_localhost_port()
     collider_repo = Collider(urllib.parse.urlparse(f'http://127.0.0.1:{closed_port}/v2/'), {})
     cmd = Publish(
-        _push_args(repository='remote', builddir=builddir), _mock_context({'remote': collider_repo})
+        _push_args(repository='remote', builddir=builddir, insecure=True),
+        _mock_context({'remote': collider_repo}),
     )
 
     os.environ['COLLIDER_PUSH_TOKEN'] = 'secret'

--- a/test/subcommand/test_delete.py
+++ b/test/subcommand/test_delete.py
@@ -231,6 +231,7 @@ def test_delete_execute_collider_success(tmp_path: Path) -> None:
             package='foo',
             version='1.0.0',
             push_token_env='COLLIDER_PUSH_TOKEN',
+            insecure=True,
         )
         cmd = Unpublish(args, context)
 
@@ -550,3 +551,23 @@ def test_delete_execute_collider_empty_push_token_env_name_returns_ex_usage(
     assert exit_code == os.EX_USAGE
     assert 'Push token env var name must not be empty.' in caplog.text
     assert '--push-token-env' in caplog.text
+
+
+def test_delete_collider_http_refused_without_insecure(tmp_path: Path, caplog) -> None:
+    """Deleting with a token over http without --insecure is refused before any network call."""
+    collider_repo = Collider(urllib.parse.urlparse('http://packages.example.com/v2/'), {})
+    config = MagicMock()
+    config.repositories = {'remote': collider_repo}
+    context = MagicMock(spec=Context)
+    context.config = config
+
+    args = argparse.Namespace(
+        repository='remote',
+        package='foo',
+        version='1.0.0',
+        push_token_env='COLLIDER_PUSH_TOKEN',
+    )
+    cmd = Unpublish(args, context)
+    with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
+        assert cmd.execute() == os.EX_USAGE
+    assert 'Refusing to send the push token' in caplog.text

--- a/test/subcommand/test_push.py
+++ b/test/subcommand/test_push.py
@@ -93,6 +93,7 @@ def _push_args(
     patch_archive: Path | None = None,
     push_token_env: str = 'COLLIDER_PUSH_TOKEN',
     dry_run: bool = False,
+    insecure: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
         repository=repository,
@@ -100,6 +101,7 @@ def _push_args(
         patch_archive=patch_archive,
         push_token_env=push_token_env,
         dry_run=dry_run,
+        insecure=insecure,
     )
 
 
@@ -348,7 +350,7 @@ def test_push_collider_repo_http_success(tmp_path: Path) -> None:
         context = MagicMock(spec=Context)
         context.config = config
 
-        cmd = Publish(_push_args(repository='remote', builddir=builddir), context)
+        cmd = Publish(_push_args(repository='remote', builddir=builddir, insecure=True), context)
         with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
             assert cmd.execute() == os.EX_OK
     finally:
@@ -380,7 +382,7 @@ def test_push_collider_repo_http_bad_token(tmp_path: Path) -> None:
         context = MagicMock(spec=Context)
         context.config = config
 
-        cmd = Publish(_push_args(repository='remote', builddir=builddir), context)
+        cmd = Publish(_push_args(repository='remote', builddir=builddir, insecure=True), context)
         with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'wrong'}):
             assert cmd.execute() == os.EX_IOERR
     finally:
@@ -408,7 +410,12 @@ def test_push_collider_repo_uses_custom_token_env(tmp_path: Path) -> None:
         context.config = config
 
         cmd = Publish(
-            _push_args(repository='remote', builddir=builddir, push_token_env='MY_PUSH_TOKEN'),
+            _push_args(
+                repository='remote',
+                builddir=builddir,
+                insecure=True,
+                push_token_env='MY_PUSH_TOKEN',
+            ),
             context,
         )
         with patch.dict(os.environ, {'MY_PUSH_TOKEN': 'secret'}, clear=True):
@@ -433,7 +440,7 @@ def test_push_collider_repo_http_unreachable_endpoint(tmp_path: Path) -> None:
     context = MagicMock(spec=Context)
     context.config = config
 
-    cmd = Publish(_push_args(repository='remote', builddir=builddir), context)
+    cmd = Publish(_push_args(repository='remote', builddir=builddir, insecure=True), context)
     with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
         assert cmd.execute() == os.EX_IOERR
 
@@ -490,7 +497,7 @@ def test_push_collider_repo_http_conflict_returns_ex_cantcreat(tmp_path: Path, c
         context = MagicMock(spec=Context)
         context.config = config
 
-        args = _push_args(repository='remote', builddir=builddir)
+        args = _push_args(repository='remote', builddir=builddir, insecure=True)
         with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
             assert Publish(args, context).execute() == os.EX_OK
 
@@ -535,7 +542,7 @@ def test_push_collider_repo_http_unexpected_status(tmp_path: Path) -> None:
         context = MagicMock(spec=Context)
         context.config = config
 
-        cmd = Publish(_push_args(repository='remote', builddir=builddir), context)
+        cmd = Publish(_push_args(repository='remote', builddir=builddir, insecure=True), context)
         with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
             assert cmd.execute() == os.EX_IOERR
     finally:
@@ -611,3 +618,26 @@ def test_dry_run_collider_repo_does_not_push(tmp_path: Path, caplog) -> None:
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_push_collider_repo_http_refused_without_insecure(tmp_path: Path, caplog) -> None:
+    """Pushing a token to an http repo without --insecure is refused before any network call."""
+    source_dir = tmp_path / 'src'
+    source_dir.mkdir()
+    builddir = tmp_path / 'build'
+    _write_projectinfo(builddir, name='demo', version='1.0.0')
+    _write_mesoninfo(builddir, source_dir)
+
+    # Unreachable port: had the gate not fired, the push would attempt a connection and return
+    # EX_IOERR. EX_USAGE proves the token was never put on the wire.
+    closed_port = _unused_localhost_port()
+    collider_repo = Collider(urllib.parse.urlparse(f'http://127.0.0.1:{closed_port}/v2/'), {})
+    config = MagicMock()
+    config.repositories = {'remote': collider_repo}
+    context = MagicMock(spec=Context)
+    context.config = config
+
+    cmd = Publish(_push_args(repository='remote', builddir=builddir), context)
+    with patch.dict(os.environ, {'COLLIDER_PUSH_TOKEN': 'secret'}):
+        assert cmd.execute() == os.EX_USAGE
+    assert 'Refusing to send the push token' in caplog.text

--- a/test/utils/test_network.py
+++ b/test/utils/test_network.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 MOG Robotics OÜ.
 
+import logging
 import threading
+import urllib.parse
 import urllib.request
 
 from functools import partial
@@ -9,7 +11,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
-from collider.utils.network import _AuthStrippingRedirectHandler, safe_urlopen
+from collider.utils.network import (
+    _AuthStrippingRedirectHandler,
+    may_send_push_token,
+    safe_urlopen,
+)
 
 
 def _make_request(url: str) -> urllib.request.Request:
@@ -119,3 +125,27 @@ def test_safe_urlopen_keeps_token_on_same_origin_redirect():
     finally:
         server.shutdown()
         thread.join()
+
+
+def test_may_send_push_token_allows_https():
+    url = urllib.parse.urlparse('https://packages.example.com/v2/')
+
+    assert may_send_push_token(url, insecure=False) is True
+
+
+def test_may_send_push_token_refuses_http_without_insecure(caplog):
+    url = urllib.parse.urlparse('http://packages.example.com/v2/')
+
+    with caplog.at_level(logging.CRITICAL, logger='collider'):
+        assert may_send_push_token(url, insecure=False) is False
+
+    assert 'Refusing to send the push token' in caplog.text
+
+
+def test_may_send_push_token_allows_http_with_insecure(caplog):
+    url = urllib.parse.urlparse('http://packages.example.com/v2/')
+
+    with caplog.at_level(logging.WARNING, logger='collider'):
+        assert may_send_push_token(url, insecure=True) is True
+
+    assert 'insecure' in caplog.text.lower()


### PR DESCRIPTION
Implements the highest-value item from the security backlog: `publish`/`unpublish` sent the bearer push token via `Authorization: Bearer` with **no scheme check**, so a repository configured with an `http://` URL leaked the credential in cleartext (a captured push token = supply-chain compromise).

## Change
- New `may_send_push_token(url, *, insecure)` in `collider/utils/network.py`: allows `https`; refuses non-`https` (hard fail) unless `--insecure`, in which case it warns and proceeds.
- `publish` and `unpublish` gain `--insecure`; the gate runs **after** loading the token and **before** any request, returning `EX_USAGE` on refusal.
- The existing cross-origin redirect handler already strips the token on an `https -> http` downgrade (scheme is part of the origin), so the gate + stripping together close the leak.
- CLI docs updated for both commands.

## Verification
- Adversarially reviewed (verdict GO): only two credentialed send sites exist, both gated; redirect-downgrade and `urljoin` scheme/host confusion are closed; `--dry-run` skips the gate; the token is never logged.
- New tests: helper unit tests + a "http refused without --insecure returns `EX_USAGE` before any network call" test for each command; existing http-server tests updated to pass `insecure=True`.
- Full gate green: ruff format/check, ty, pylint 10.00, pytest 764 passed.

## Type of change

- [x] New feature

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass.

## AI disclosure

- [ ] AI tools were used for part or all of this change.
  - [ ] A human (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.