### PR TITLE
feat(setup): fail on wrap drift from collider.lock, add --allow-drift

### DIFF
--- a/collider/subcommand/Setup.py
+++ b/collider/subcommand/Setup.py
@@ -24,6 +24,7 @@ from collider.utils.meson.infoTypes import ProjectInfo
 from collider.utils.packaging import validate_dependencies
 from collider.utils.project_state import (
     collect_force_fallback_names,
+    detect_locked_wrap_drift,
     managed_package_names,
     scan_wraps,
 )
@@ -70,6 +71,14 @@ Examples:
         )
 
         parser.add_argument(
+            '--allow-drift',
+            action='store_true',
+            default=False,
+            help='Build even if an installed wrap differs from collider.lock (warns instead of '
+            'failing).',
+        )
+
+        parser.add_argument(
             'meson_setup_args',
             nargs=argparse.REMAINDER,
             help='Arguments passed directly to "meson setup". Use "--" to separate from collider arguments.',
@@ -84,6 +93,7 @@ Examples:
         super().__init__(args, context)
         self.sourcedir: Path = args.sourcedir
         self.builddir: Path = args.builddir
+        self.allow_drift: bool = getattr(args, 'allow_drift', False)
         self.meson_setup_args = args.meson_setup_args
 
         if self.meson_setup_args:
@@ -121,6 +131,8 @@ Examples:
             return os.EX_NOINPUT
 
         try:
+            if not self._verify_no_lock_drift():
+                return os.EX_DATAERR
             fallback_args = self._force_fallback_args()
         except ValueError as exc:
             logger.critical(str(exc))
@@ -143,6 +155,33 @@ Examples:
             return os.EX_DATAERR
 
         return os.EX_OK
+
+    def _verify_no_lock_drift(self) -> bool:
+        """
+        Refuse to build when an installed wrap drifted from collider.lock.
+        A drifted wrap means the configured build no longer matches the locked resolution, so the
+        default is to fail fast; --allow-drift downgrades this to a loud warning for the legitimate
+        local-patch workflow.
+        :return: True when setup may proceed, False when it must abort.
+        :raises ValueError: When collider.lock exists but is malformed.
+        """
+        drifted = detect_locked_wrap_drift(self.sourcedir)
+        if not drifted:
+            return True
+
+        report = logger.warning if self.allow_drift else logger.critical
+        for name in drifted:
+            report(f'"{name}.wrap" differs from the hash recorded in collider.lock.')
+
+        if self.allow_drift:
+            logger.warning(
+                'Continuing despite wrap drift because --allow-drift was passed; '
+                'the build may not match collider.lock.'
+            )
+            return True
+
+        logger.critical('Run "collider lock" to re-lock, or pass --allow-drift to build anyway.')
+        return False
 
     @staticmethod
     def _user_forces_fallback(meson_args: list[str]) -> bool:

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Optional
 
 from collider.file_model.colliderfile import Colliderfile
-from collider.file_model.lockfile import Lockfile
+from collider.file_model.lockfile import Lockfile, compute_wrap_hash
 from collider.log import logger
 from collider.Package import get_provide_names
 from collider.utils.meson import SUBPROJECTS_DIR
@@ -122,6 +122,46 @@ def managed_package_names(sourcedir: Path) -> Optional[set[str]]:
             dep.name for dep in colliderfile.dependencies if dep.source == DependencySource.COLLIDER
         }
     return names
+
+
+def detect_locked_wrap_drift(sourcedir: Path) -> list[str]:
+    """
+    Find locked wraps whose on-disk bytes no longer match collider.lock.
+    Only wraps that are recorded in the lock and present on disk are compared; a missing wrap
+    is not treated as drift here (Meson resolution and `collider status` cover that case). The
+    hash is taken over the .wrap file text only, so this detects edits to the wrap descriptor,
+    not changes to the extracted subproject source tree.
+    :param sourcedir: Project source directory.
+    :return: Sorted names of wraps that drifted from the lock; empty when none or no lock.
+    :raises ValueError: When collider.lock exists but cannot be parsed.
+    """
+    lock_path = sourcedir / Lockfile.get_filename()
+    if not lock_path.exists():
+        return []
+
+    try:
+        lockfile = Lockfile.from_path(lock_path)
+    except Exception as exc:
+        raise ValueError(f'collider.lock is malformed: {exc}') from exc
+
+    subprojects_dir = sourcedir / SUBPROJECTS_DIR
+    drifted: list[str] = []
+    for name, locked in lockfile.all_packages.items():
+        wrap_path = subprojects_dir / f'{name}.wrap'
+        if not wrap_path.is_file():
+            continue
+        try:
+            wrap_text = wrap_path.read_text(encoding='utf-8')
+        except OSError as exc:
+            logger.debug(f'Cannot read "{wrap_path}" for drift check, skipping: {exc}')
+            continue
+        except UnicodeDecodeError:
+            # A non-UTF-8 wrap can never match a UTF-8-hashed lock entry, so it is drift.
+            drifted.append(name)
+            continue
+        if compute_wrap_hash(wrap_text) != locked.wrap_hash:
+            drifted.append(name)
+    return sorted(drifted)
 
 
 def collect_force_fallback_names(

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,13 +43,14 @@ emitted at init time to avoid discovering the gap only when publishing.
 Configure a Meson project.
 
 ```bash
-collider setup [--sourcedir PATH] [--builddir PATH] -- [meson args]
+collider setup [--sourcedir PATH] [--builddir PATH] [--allow-drift] -- [meson args]
 ```
 
 | Option            | Description                                      |
 |-------------------|--------------------------------------------------|
 | `--sourcedir PATH` | Meson source directory.                         |
 | `--builddir PATH`  | Meson build directory (default: `collider-build`). |
+| `--allow-drift`    | Build even if an installed wrap differs from `collider.lock` (warn instead of fail). |
 | `-- [args]`        | Arguments passed through to Meson.              |
 
 **Examples:**
@@ -65,7 +66,16 @@ collider setup -- --buildtype=debug
 than system copies. The forced set is scoped to `collider.lock` when present, or
 all wraps in `subprojects/` (with a warning) when it is absent; a malformed
 `collider.lock` aborts with `EX_DATAERR`. A user-supplied `--force-fallback-for`
-or `-Dforce_fallback_for` is honored as-is. See
+or `-Dforce_fallback_for` is honored as-is.
+
+When `collider.lock` is present, setup verifies that each locked wrap on disk
+still matches its recorded hash. If an installed `.wrap` was modified, setup
+aborts with `EX_DATAERR` before configuring Meson; run `collider lock` to
+re-lock or pass `--allow-drift` to build anyway (downgrades to a warning). The
+hash covers the `.wrap` descriptor only, not the extracted subproject source. A
+wrap committed into a consumer repo under Git line-ending normalization
+(`core.autocrlf` or a `.gitattributes` `text` rule) can be re-hashed differently
+than it was locked and trip the gate; use `--allow-drift` if that applies. See
 [Wrap Fallback Enforcement](../guide/project-setup.md#wrap-fallback-enforcement).
 
 ---

--- a/test/subcommand/test_setup.py
+++ b/test/subcommand/test_setup.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from collider.Context import Context
-from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.file_model.lockfile import LockedPackage, Lockfile, compute_wrap_hash
 from collider.subcommand.Setup import Setup
 from collider.utils import meson
 from test.common.common import Subcommand, run_subcommand
@@ -250,10 +250,12 @@ def test_setup_with_lock_scopes_force_to_managed_packages(
         '[wrap-file]\ndirectory = bar\nsource_url = https://example.invalid/bar.tar.gz\n'
         f'source_filename = bar.tar.gz\nsource_hash = {"0" * 64}\n\n[provide]\nbar = bar_dep\n'
     )
+    # The lock must record foo's real hash, otherwise the drift gate aborts before force-scoping.
+    foo_hash = compute_wrap_hash((sourcedir / 'subprojects' / 'foo.wrap').read_text())
     Lockfile(
         dependencies={
             'foo': LockedPackage(
-                version='1.2.3', wrap_hash='sha256:' + '0' * 64, origin='https://wrapdb.example/v2/'
+                version='1.2.3', wrap_hash=foo_hash, origin='https://wrapdb.example/v2/'
             )
         },
     ).save(sourcedir / Lockfile.get_filename())
@@ -316,6 +318,61 @@ def test_setup_malformed_lock_errors(tmp_path: Path, capfd: pytest.CaptureFixtur
     stdout, stderr = capfd.readouterr()
     assert 'collider.lock is malformed' in stderr
     assert not builddir.exists()
+
+
+def test_setup_drifted_wrap_aborts_before_meson(tmp_path: Path, capfd: pytest.CaptureFixture):
+    """A wrap whose bytes differ from the lock aborts setup with EX_DATAERR, before Meson runs."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    # Lock foo with a hash that cannot match the on-disk foo.wrap, forcing drift.
+    Lockfile(
+        dependencies={
+            'foo': LockedPackage(
+                version='1.2.3', wrap_hash='sha256:' + '0' * 64, origin='https://wrapdb.example/v2/'
+            )
+        },
+    ).save(sourcedir / Lockfile.get_filename())
+
+    builddir = tmp_path / 'build'
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(builddir)],
+        )
+        == os.EX_DATAERR
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert '"foo.wrap" differs from the hash recorded in collider.lock' in stderr
+    assert '--allow-drift' in stderr
+    # The gate must fail fast: Meson is never configured.
+    assert not builddir.exists()
+
+
+def test_setup_drifted_wrap_allowed_with_flag(tmp_path: Path, capfd: pytest.CaptureFixture):
+    """--allow-drift downgrades drift to a warning and lets the build proceed."""
+    sourcedir = tmp_path / 'project'
+    _write_wrapped_foo_project(sourcedir)
+    Lockfile(
+        dependencies={
+            'foo': LockedPackage(
+                version='1.2.3', wrap_hash='sha256:' + '0' * 64, origin='https://wrapdb.example/v2/'
+            )
+        },
+    ).save(sourcedir / Lockfile.get_filename())
+
+    assert (
+        run_subcommand(
+            Subcommand.SETUP,
+            ['--sourcedir', str(sourcedir), '--builddir', str(tmp_path / 'build'), '--allow-drift'],
+            verbose=True,
+        )
+        == os.EX_OK
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert 'Continuing despite wrap drift' in stderr
+    assert '--force-fallback-for=foo' in stderr
 
 
 def test_setup_defers_to_user_supplied_force_fallback(tmp_path: Path, capfd: pytest.CaptureFixture):

--- a/test/utils/test_project_state.py
+++ b/test/utils/test_project_state.py
@@ -8,9 +8,13 @@ from pathlib import Path
 import pytest
 
 from collider.file_model.colliderfile import Colliderfile
-from collider.file_model.lockfile import LockedPackage, Lockfile
+from collider.file_model.lockfile import LockedPackage, Lockfile, compute_wrap_hash
 from collider.utils.packaging.Dependency import Dependency, DependencySource
-from collider.utils.project_state import collect_force_fallback_names, managed_package_names
+from collider.utils.project_state import (
+    collect_force_fallback_names,
+    detect_locked_wrap_drift,
+    managed_package_names,
+)
 
 
 _ORIGIN = 'https://wrapdb.example.com/v2/'
@@ -160,3 +164,72 @@ def test_managed_names_tolerates_malformed_colliderfile(tmp_path: Path) -> None:
     ).save(tmp_path / Lockfile.get_filename())
     (tmp_path / Colliderfile.get_filename()).write_text('{ not valid json', encoding='utf-8')
     assert managed_package_names(tmp_path) == {'foo'}
+
+
+def _lock_with(tmp_path: Path, **packages: str) -> None:
+    """Save a lockfile pinning each package name to the given wrap_hash."""
+    Lockfile(
+        dependencies={
+            name: LockedPackage(version='1.0', wrap_hash=wrap_hash, origin=_ORIGIN)
+            for name, wrap_hash in packages.items()
+        }
+    ).save(tmp_path / Lockfile.get_filename())
+
+
+def test_drift_returns_empty_without_lock(tmp_path: Path) -> None:
+    """No lock means nothing to compare against, even when a wrap is present."""
+    _write_wrap(tmp_path / 'subprojects', 'foo', _wrap_file_text('foo'))
+    assert detect_locked_wrap_drift(tmp_path) == []
+
+
+def test_drift_empty_when_hash_matches(tmp_path: Path) -> None:
+    """A wrap whose bytes match the locked hash is not drift."""
+    text = _wrap_file_text('foo')
+    _write_wrap(tmp_path / 'subprojects', 'foo', text)
+    _lock_with(tmp_path, foo=compute_wrap_hash(text))
+    assert detect_locked_wrap_drift(tmp_path) == []
+
+
+def test_drift_detects_modified_wrap(tmp_path: Path) -> None:
+    """A wrap whose bytes differ from the locked hash is reported as drift."""
+    _write_wrap(tmp_path / 'subprojects', 'foo', _wrap_file_text('foo'))
+    _lock_with(tmp_path, foo='sha256:' + '0' * 64)
+    assert detect_locked_wrap_drift(tmp_path) == ['foo']
+
+
+def test_drift_ignores_missing_wrap(tmp_path: Path) -> None:
+    """A locked package with no wrap on disk is not drift (missing is a separate concern)."""
+    _lock_with(tmp_path, foo='sha256:' + '0' * 64)
+    assert detect_locked_wrap_drift(tmp_path) == []
+
+
+def test_drift_reports_only_modified_sorted(tmp_path: Path) -> None:
+    """Only mismatching wraps are reported, sorted, with matching ones excluded."""
+    subprojects = tmp_path / 'subprojects'
+    fmt_text = _wrap_file_text('fmt')
+    _write_wrap(subprojects, 'fmt', fmt_text)
+    _write_wrap(subprojects, 'bar', _wrap_file_text('bar'))
+    _write_wrap(subprojects, 'baz', _wrap_file_text('baz'))
+    _lock_with(
+        tmp_path,
+        fmt=compute_wrap_hash(fmt_text),  # matches: not drift
+        bar='sha256:' + '0' * 64,  # drift
+        baz='sha256:' + '1' * 64,  # drift
+    )
+    assert detect_locked_wrap_drift(tmp_path) == ['bar', 'baz']
+
+
+def test_drift_treats_non_utf8_wrap_as_drift(tmp_path: Path) -> None:
+    """A non-UTF-8 wrap cannot match a UTF-8-hashed lock entry, so it counts as drift."""
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir(parents=True)
+    (subprojects / 'foo.wrap').write_bytes(b'\xff\xfe[wrap-file]\x00')
+    _lock_with(tmp_path, foo='sha256:' + '0' * 64)
+    assert detect_locked_wrap_drift(tmp_path) == ['foo']
+
+
+def test_drift_raises_on_malformed_lock(tmp_path: Path) -> None:
+    """A malformed lock is a hard error, mirroring managed_package_names."""
+    (tmp_path / Lockfile.get_filename()).write_text('{ not valid json', encoding='utf-8')
+    with pytest.raises(ValueError, match='malformed'):
+        detect_locked_wrap_drift(tmp_path)


### PR DESCRIPTION
## Summary

`collider setup` now verifies that each locked wrap on disk still matches the hash recorded in `collider.lock`, before running `meson setup`. A present-but-modified wrap aborts with `EX_DATAERR` and a remediation message; `--allow-drift` downgrades the failure to a loud warning for the local-patch workflow. Missing wraps are not treated as drift, and `install`/`status` behavior is unchanged.

Previously `setup` read the lock only to scope `--force-fallback-for` by name and never checked wrap integrity, so a drifted wrap was built silently. The hash covers the `.wrap` descriptor only, not the extracted subproject source.

Closes #69

## Type of change

- [x] New feature

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.