### PR TITLE
docs(pr-template): clarify AI disclosure with "Tick all that apply"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Brief description of the change.
 - [ ] Tests pass (`uv run pytest`).
 - [ ] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).
 
-## AI disclosure
+## AI disclosure (Tick all that apply)
 
 - [ ] AI tools were used for part or all of this change.
   - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.


### PR DESCRIPTION
## Summary

Rename the PR template's "AI disclosure" heading to "AI disclosure (Tick all that apply)" so the two checkboxes read as a combined disclosure rather than a single yes/no.

## Type of change

- [x] Documentation

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.