### PR TITLE
feat: harden untrusted repository metadata handling

### DIFF
--- a/collider/repository/entries.py
+++ b/collider/repository/entries.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
 
-from collider.log import logger
 from collider.utils.core import is_safe_path_segment
 from collider.utils.meson.infoTypes import WrapDbReleases
 from collider.utils.packaging.PackageType import PackageType

--- a/collider/repository/entries.py
+++ b/collider/repository/entries.py
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from enum import Enum
+from typing import Any, Optional
 
 from collider.log import logger
 from collider.utils.core import is_safe_path_segment
@@ -14,6 +15,22 @@ from collider.utils.meson.infoTypes import WrapDbReleases
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key, parse_repo_key
 from collider.utils.packaging.types import RepoKey
+
+
+class RejectReason(Enum):
+    """Why a releases.json entry was rejected at the index boundary."""
+
+    STRUCTURE = 'structure'
+    UNSAFE_NAME = 'unsafe_name'
+    UNSAFE_VERSION = 'unsafe_version'
+
+
+@dataclass(frozen=True)
+class RejectedEntry:
+    """A releases.json entry that could not be indexed, with the reason it was dropped."""
+
+    name: str
+    reason: RejectReason
 
 
 @dataclass(frozen=True)
@@ -58,28 +75,56 @@ def add_wrap_entry(
     )
 
 
+def _read_dep_names(entry: Any) -> Optional[list[str]]:
+    """
+    Return an entry's declared provides when they are a clean list of strings, else None.
+    None means "absent or untrustworthy"; it must not be confused with "declares no provides".
+    :param entry: A single releases.json entry object.
+    :return: Sorted, de-duplicated dependency names, or None.
+    """
+    dep_names = entry.get('dependency_names')
+    if dep_names is None:
+        return None
+    if not isinstance(dep_names, list) or not all(isinstance(d, str) for d in dep_names):
+        return None
+    return sorted(set(dep_names))
+
+
 def packages_from_releases(
     releases: WrapDbReleases,
-) -> dict[RepoKey, RepoPackageEntry]:
+) -> tuple[dict[RepoKey, RepoPackageEntry], list[RejectedEntry]]:
     """
     Build a package index from a WrapDB-compatible releases.json map.
+    Malformed metadata is untrusted input, so a bad entry is skipped (never raised) and recorded in
+    the returned reject list rather than dropping the whole repository. Names and versions become
+    filesystem paths and URL segments downstream, so unsafe segments are dropped at this boundary.
     :param releases: Raw releases map (e.g. from releases.json).
-    :return: Map from repo key to RepoPackageEntry.
+    :return: A (package index, rejected entries) pair.
     """
     packages: dict[RepoKey, RepoPackageEntry] = {}
+    rejected: list[RejectedEntry] = []
+
+    if not isinstance(releases, dict):
+        return packages, [RejectedEntry('', RejectReason.STRUCTURE)]
+
     for name, entry in releases.items():
-        # Names and versions from an untrusted releases.json become filesystem
-        # paths downstream; drop unsafe ones at the index boundary.
-        if not is_safe_path_segment(name):
-            logger.debug(f'Skipping release with unsafe name: "{name}".')
+        if not isinstance(name, str) or not is_safe_path_segment(name):
+            rejected.append(RejectedEntry(str(name), RejectReason.UNSAFE_NAME))
             continue
+        if not isinstance(entry, dict):
+            rejected.append(RejectedEntry(name, RejectReason.STRUCTURE))
+            continue
+
+        dependency_names = _read_dep_names(entry)
         versions = entry.get('versions', [])
-        dependency_names = entry.get('dependency_names')
-        if dependency_names is not None:
-            dependency_names = sorted(set(dependency_names))
+        if not isinstance(versions, list):
+            rejected.append(RejectedEntry(name, RejectReason.STRUCTURE))
+            continue
+
         for version in versions:
-            if not is_safe_path_segment(version):
-                logger.debug(f'Skipping unsafe version "{version}" for "{name}".')
+            if not isinstance(version, str) or not is_safe_path_segment(version):
+                rejected.append(RejectedEntry(name, RejectReason.UNSAFE_VERSION))
                 continue
             add_wrap_entry(packages, name, version, dependency_names)
-    return packages
+
+    return packages, rejected

--- a/collider/repository/implementation/RepositoryInterface.py
+++ b/collider/repository/implementation/RepositoryInterface.py
@@ -13,7 +13,7 @@ from typing import Optional, final
 from packaging.specifiers import SpecifierSet
 
 from collider.Package import WrapPackage
-from collider.repository.entries import RepoPackageEntry
+from collider.repository.entries import RejectedEntry, RepoPackageEntry
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key, parse_repo_key
 from collider.utils.packaging.types import RepoKey
@@ -26,8 +26,13 @@ class PackageAlreadyExistsError(ValueError):
 class RepositoryInterface(ABC):
     """Shared repository API so callers are backend-agnostic."""
 
-    def __init__(self, packages: dict[RepoKey, RepoPackageEntry]) -> None:
+    def __init__(
+        self,
+        packages: dict[RepoKey, RepoPackageEntry],
+        rejected_metadata: Optional[list[RejectedEntry]] = None,
+    ) -> None:
         self.packages = packages
+        self.rejected_metadata: list[RejectedEntry] = rejected_metadata or []
         self._origin_url: str = ''
 
     @property

--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from collider.log import logger
 from collider.Package import WrapPackage
-from collider.repository.entries import RepoPackageEntry, packages_from_releases
+from collider.repository.entries import RejectedEntry, RepoPackageEntry, packages_from_releases
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.utils.core import assert_safe_path_segment
 from collider.utils.fs import atomic_write_text
@@ -37,8 +37,8 @@ def _get_pkg_wrap_url(url: urllib.parse.ParseResult, package: RepoPackageEntry) 
 
 def _wrap_releases_to_packages(
     wrap_releases: dict[str, WrapDbReleasesEntry],
-) -> dict[RepoKey, RepoPackageEntry]:
-    """Convert WrapDB releases to an in-memory package index."""
+) -> tuple[dict[RepoKey, RepoPackageEntry], list[RejectedEntry]]:
+    """Convert WrapDB releases to an in-memory package index and its rejected entries."""
     return packages_from_releases(wrap_releases)
 
 
@@ -72,14 +72,18 @@ class Wrap(RepositoryInterface):
     """Read-only WrapDB-compatible repository client."""
 
     def __init__(
-        self, url: urllib.parse.ParseResult, packages: dict[RepoKey, RepoPackageEntry]
+        self,
+        url: urllib.parse.ParseResult,
+        packages: dict[RepoKey, RepoPackageEntry],
+        rejected_metadata: Optional[list[RejectedEntry]] = None,
     ) -> None:
         """
         Build a Wrap repository from a base URL and preloaded package index.
         :param url: Base URL for the WrapDB-compatible API (e.g. wrapdb.mesonbuild.com/v2/).
         :param packages: Preloaded package index (e.g. from releases.json).
+        :param rejected_metadata: Entries dropped while parsing releases.json.
         """
-        super().__init__(packages)
+        super().__init__(packages, rejected_metadata=rejected_metadata)
         self.url = url
 
     # Repo operations.
@@ -129,8 +133,14 @@ class Wrap(RepositoryInterface):
                 logger.warning('Failed to refresh wrap releases; using cached data.')
                 releases = json.loads(cache_file.read_text(encoding='utf-8'))
 
-        packages = _wrap_releases_to_packages(releases)
-        return cls(effective_url, packages)
+        packages, rejected = _wrap_releases_to_packages(releases)
+        if rejected:
+            logger.warning(
+                f'{len(rejected)} releases.json entr'
+                f'{"y" if len(rejected) == 1 else "ies"} from "{effective_url.geturl()}" '
+                'skipped due to malformed metadata.'
+            )
+        return cls(effective_url, packages, rejected_metadata=rejected)
 
     def _update_impl(self) -> None:
         pass

--- a/collider/subcommand/Install.py
+++ b/collider/subcommand/Install.py
@@ -35,6 +35,7 @@ from collider.utils.packaging.Dependency import DependencySource
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
 from collider.utils.packaging.resolver import (
+    MalformedRepositoryMetadata,
     RootSpec,
     build_dep_name_index,
     resolve_all_dependencies,
@@ -247,10 +248,14 @@ class Install(SubcommandInterface):
                     roots=root_specs,
                     repos=repos,
                     offline=self.offline,
+                    strict=True,
                     wrap_cache=self.context.cache,
                     include_conditional=any(dep.include_conditional for dep in collider_deps),
                     exclude_optional=any(dep.exclude_optional for dep in collider_deps),
                 )
+            except MalformedRepositoryMetadata as e:
+                logger.critical(f'Refusing to install against malformed repository metadata: {e}')
+                return os.EX_DATAERR
             except (
                 resolvelib.RequirementsConflicted,
                 resolvelib.ResolutionImpossible,

--- a/collider/subcommand/Lock.py
+++ b/collider/subcommand/Lock.py
@@ -17,12 +17,14 @@ from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import LockedPackage, Lockfile
 from collider.log import logger
 from collider.repository.entries import RepoPackageEntry
+from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.Install import Install as InstallSubcommand
 from collider.utils.compat import override
 from collider.utils.packaging.Dependency import DependencySource
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
 from collider.utils.packaging.resolver import (
+    Candidate,
     MalformedRepositoryMetadata,
     RootSpec,
     build_dep_name_index,
@@ -132,33 +134,9 @@ class Lock(InstallSubcommand):
                 return os.EX_UNAVAILABLE
 
             direct_names = {dep.name for dep in collider_deps}
-            for pkg_name, candidate in resolution.mapping.items():
-                repo = repos.get(candidate.repo_name)
-                if repo is None:
-                    logger.warning(
-                        f'Repository "{candidate.repo_name}" unavailable for "{pkg_name}".'
-                    )
-                    continue
-
-                repo_key = make_repo_key(pkg_name, candidate.version, PackageType.WRAP)
-                entry = RepoPackageEntry(pkg_name, candidate.version, PackageType.WRAP)
-                package = self._fetch_package(entry, repo, repo_key)
-                if package is None:
-                    return os.EX_IOERR
-
-                try:
-                    self.context.cache.verify_archives(package, offline=self.offline)
-                except (ValueError, FileNotFoundError) as e:
-                    logger.critical(f'Archive verification failed for "{pkg_name}": {e}')
-                    return os.EX_DATAERR
-
-                locked = LockedPackage.from_wrap_text(
-                    candidate.version, package.wrap_text, normalize_url(repo.origin_url)
-                )
-                if pkg_name in direct_names:
-                    lockfile.dependencies[pkg_name] = locked
-                else:
-                    lockfile.packages[pkg_name] = locked
+            error = self._lock_resolved_packages(resolution.mapping, direct_names, repos, lockfile)
+            if error is not None:
+                return error
         else:
             for dep in collider_deps:
                 version_spec, _ = self._parse_version_spec(dep.name, dep.version)
@@ -188,6 +166,48 @@ class Lock(InstallSubcommand):
         lockfile.save()
         logger.info('Lockfile written.')
         return os.EX_OK
+
+    def _lock_resolved_packages(
+        self,
+        mapping: dict[str, Candidate],
+        direct_names: set[str],
+        repos: dict[str, RepositoryInterface],
+        lockfile: Lockfile,
+    ) -> Optional[int]:
+        """
+        Fetch and pin each resolved candidate into the lockfile.
+        :param mapping: Resolved package name to selected candidate.
+        :param direct_names: Names of directly-declared dependencies.
+        :param repos: Configured repositories.
+        :param lockfile: Lockfile to populate in place.
+        :return: An error exit code on failure, else None.
+        """
+        for pkg_name, candidate in mapping.items():
+            repo = repos.get(candidate.repo_name)
+            if repo is None:
+                logger.warning(f'Repository "{candidate.repo_name}" unavailable for "{pkg_name}".')
+                continue
+
+            repo_key = make_repo_key(pkg_name, candidate.version, PackageType.WRAP)
+            entry = RepoPackageEntry(pkg_name, candidate.version, PackageType.WRAP)
+            package = self._fetch_package(entry, repo, repo_key)
+            if package is None:
+                return os.EX_IOERR
+
+            try:
+                self.context.cache.verify_archives(package, offline=self.offline)
+            except (ValueError, FileNotFoundError) as e:
+                logger.critical(f'Archive verification failed for "{pkg_name}": {e}')
+                return os.EX_DATAERR
+
+            locked = LockedPackage.from_wrap_text(
+                candidate.version, package.wrap_text, normalize_url(repo.origin_url)
+            )
+            if pkg_name in direct_names:
+                lockfile.dependencies[pkg_name] = locked
+            else:
+                lockfile.packages[pkg_name] = locked
+        return None
 
     @staticmethod
     def _validate_cwd() -> bool:

--- a/collider/subcommand/Lock.py
+++ b/collider/subcommand/Lock.py
@@ -23,6 +23,7 @@ from collider.utils.packaging.Dependency import DependencySource
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
 from collider.utils.packaging.resolver import (
+    MalformedRepositoryMetadata,
     RootSpec,
     build_dep_name_index,
     resolve_all_dependencies,
@@ -114,10 +115,14 @@ class Lock(InstallSubcommand):
                     roots=root_specs,
                     repos=repos,
                     offline=self.offline,
+                    strict=True,
                     wrap_cache=self.context.cache,
                     include_conditional=any(dep.include_conditional for dep in collider_deps),
                     exclude_optional=any(dep.exclude_optional for dep in collider_deps),
                 )
+            except MalformedRepositoryMetadata as e:
+                logger.critical(f'Refusing to lock against malformed repository metadata: {e}')
+                return os.EX_DATAERR
             except (
                 resolvelib.RequirementsConflicted,
                 resolvelib.ResolutionImpossible,

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -34,6 +34,7 @@ from collider.utils.packaging.Dependency import Dependency, DependencySource
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
 from collider.utils.packaging.resolver import (
+    MalformedRepositoryMetadata,
     ResolutionSummary,
     RootSpec,
     build_dep_name_index,
@@ -482,12 +483,16 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
                 root_version_spec=version_spec_str,
                 repos=repos,
                 offline=self.offline,
+                strict=True,
                 wrap_cache=self.context.cache,
                 include_conditional=self.include_conditional,
                 exclude_optional=self.exclude_optional,
                 include_names=include_set,
                 exclude_names=exclude_set,
             )
+        except MalformedRepositoryMetadata as e:
+            logger.critical(f'Refusing to install against malformed repository metadata: {e}')
+            return os.EX_DATAERR
         except (
             resolvelib.RequirementsConflicted,
             resolvelib.ResolutionImpossible,

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -37,7 +37,7 @@ from collider.utils.packaging.repo_key import make_repo_key
 
 
 if TYPE_CHECKING:
-    from collider.repository.entries import RepoPackageEntry
+    from collider.repository.entries import RejectedEntry, RejectReason, RepoPackageEntry
     from collider.repository.implementation.RepositoryInterface import RepositoryInterface
     from collider.utils.packaging.types import RepoKey
 
@@ -92,6 +92,35 @@ class Candidate:
         return f'Candidate({self.name!r}, {self.version!r}, {self.repo_name!r})'
 
 
+class MalformedRepositoryMetadata(Exception):
+    """
+    A package the resolver actually needs has no usable version because its repository metadata was
+    rejected. Raised only in strict resolution (lock/install/add) so trust-sensitive operations fail
+    closed instead of silently dropping the dependency.
+    """
+
+    def __init__(self, name: str, reason: 'RejectReason'):
+        self.name = name
+        self.reason = reason
+        super().__init__(f'Repository metadata for "{name}" is malformed ({reason.value}).')
+
+
+def build_rejected_name_index(
+    repos: dict[str, 'RepositoryInterface'],
+) -> dict[str, 'RejectedEntry']:
+    """
+    Index rejected releases entries by package name.
+    :param repos: Configured repositories keyed by name.
+    :return: Map from rejected package name to its first reject record.
+    """
+    index: dict[str, 'RejectedEntry'] = {}
+    for repo in repos.values():
+        for rejected in getattr(repo, 'rejected_metadata', []):
+            if rejected.name:
+                index.setdefault(rejected.name, rejected)
+    return index
+
+
 def build_dep_name_index(
     repos: dict[str, 'RepositoryInterface'],
 ) -> dict[str, str]:
@@ -123,6 +152,7 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
         dep_name_index: dict[str, str],
         *,
         offline: bool = False,
+        strict: bool = False,
         wrap_cache: Optional['WrapCache'] = None,
         include_conditional: bool = False,
         exclude_optional: bool = False,
@@ -134,6 +164,12 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
         self.repos = repos
         self.dep_name_index = dep_name_index
         self.offline = offline
+        self.strict = strict
+        # Strict resolution maps a needed package name back to metadata rejected at the index
+        # boundary, so trust-sensitive ops fail closed instead of silently dropping the dependency.
+        # Scoped to package names only: an unmapped dependency() name is indistinguishable from a
+        # system dependency, so keying fail-closed on attacker-declared provides would be a DoS.
+        self.rejected_by_name = build_rejected_name_index(repos) if strict else {}
         self.wrap_cache = wrap_cache
         self.include_conditional = include_conditional
         self.exclude_optional = exclude_optional
@@ -180,6 +216,16 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
         candidates = self._collect_matches(all_matches, reqs, bad, allow_prereleases=False)
         if not candidates:
             candidates = self._collect_matches(all_matches, reqs, bad, allow_prereleases=True)
+
+        # Fail closed when a needed package has no usable version anywhere AND its metadata was
+        # rejected: the rejection is why it is unresolvable, so surface that instead of a generic
+        # "no matching version". A package that still has valid versions is left to normal
+        # resolution (and was already warned about), so one bad sibling never breaks the build.
+        if self.strict and identifier in self.rejected_by_name:
+            total_indexed = sum(len(pkgs) for pkgs in all_matches.values())
+            if total_indexed == 0:
+                rejected = self.rejected_by_name[identifier]
+                raise MalformedRepositoryMetadata(identifier, rejected.reason)
 
         candidates.sort(key=lambda x: x[0], reverse=True)
         return [c for _, c in candidates]
@@ -557,6 +603,7 @@ def resolve_dependencies(
     repos: dict[str, 'RepositoryInterface'],
     *,
     offline: bool = False,
+    strict: bool = False,
     wrap_cache: Optional['WrapCache'] = None,
     include_conditional: bool = False,
     exclude_optional: bool = False,
@@ -569,12 +616,15 @@ def resolve_dependencies(
     :param root_version_spec: Optional version constraint string.
     :param repos: Configured repositories.
     :param offline: Disable network access during scanning.
+    :param strict: Fail closed on malformed metadata for a needed dependency.
     :param wrap_cache: Local wrap cache for offline resolution.
     :param include_conditional: Include conditional deps.
     :param exclude_optional: Exclude optional deps.
     :param include_names: Force-include specific dep names.
     :param exclude_names: Force-exclude specific dep names.
     :return: ResolutionResult with mapping and summary.
+    :raises MalformedRepositoryMetadata: In strict mode, when a needed dependency is unresolvable
+        because its repository metadata was rejected.
     """
     dep_name_index = build_dep_name_index(repos)
 
@@ -582,6 +632,7 @@ def resolve_dependencies(
         repos,
         dep_name_index,
         offline=offline,
+        strict=strict,
         wrap_cache=wrap_cache,
         include_conditional=include_conditional,
         exclude_optional=exclude_optional,
@@ -623,6 +674,7 @@ def resolve_all_dependencies(
     repos: dict[str, 'RepositoryInterface'],
     *,
     offline: bool = False,
+    strict: bool = False,
     wrap_cache: Optional['WrapCache'] = None,
     include_conditional: bool = False,
     exclude_optional: bool = False,
@@ -633,10 +685,13 @@ def resolve_all_dependencies(
     :param roots: Root packages to resolve together.
     :param repos: Configured repositories.
     :param offline: Disable network access during scanning.
+    :param strict: Fail closed on malformed metadata for a needed dependency.
     :param wrap_cache: Local wrap cache for offline resolution.
     :param include_conditional: Include conditional deps.
     :param exclude_optional: Exclude optional deps.
     :return: ResolutionResult with a unified mapping and summary.
+    :raises MalformedRepositoryMetadata: In strict mode, when a needed dependency is unresolvable
+        because its repository metadata was rejected.
     """
     root_overrides: dict[str, tuple[Optional[set[str]], Optional[set[str]]]] = {}
     for root in roots:
@@ -649,6 +704,7 @@ def resolve_all_dependencies(
         repos,
         dep_name_index,
         offline=offline,
+        strict=strict,
         wrap_cache=wrap_cache,
         include_conditional=include_conditional,
         exclude_optional=exclude_optional,

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -305,12 +305,18 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
         Scan the candidate's meson.build for dependency() calls and return
         requirements for each dependency that maps to a known package.
         """
-        cache_key = f'{candidate.name}_{candidate.version}'
+        # Key the scan cache by repo too: two repos serving the same name+version are
+        # distinct packages, so reusing one's scan for the other would bake the wrong
+        # dependency graph into collider.lock.
+        cache_key = f'{candidate.name}_{candidate.version}_{candidate.repo_name}'
         if cache_key in self.scan_cache:
             scanned = self.scan_cache[cache_key]
         else:
             scanned = None
-            if self.wrap_cache is not None:
+            # The disk scan cache is keyed by name+version only and cannot tell two repos'
+            # same-versioned packages apart. Trust it only offline (where there is no repo to
+            # re-fetch from); online, always rescan the resolver-selected candidate.
+            if self.offline and self.wrap_cache is not None:
                 scanned = self.wrap_cache.load_scan(candidate.name, candidate.version)
             if scanned is None:
                 scanned = self._scan_candidate(candidate)
@@ -387,10 +393,9 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
                 )
                 return []
         else:
-            if self.wrap_cache is not None:
-                package = self.wrap_cache.load_wrap(candidate.name, candidate.version)
-            if package is None:
-                package = repo.get_package(repo_key)
+            # Online, fetch the wrap from the resolver-selected repo rather than the
+            # name+version-keyed cache, which may hold a same-versioned wrap from another repo.
+            package = repo.get_package(repo_key)
 
         if package is None:
             logger.warning(f'Could not fetch "{candidate.name}" for dependency scan.')

--- a/docs/development/design.md
+++ b/docs/development/design.md
@@ -55,6 +55,11 @@ Patch archives may use any extension; `collider patch` produces `.tar.xz` by def
 ### Wrap Repository (Remote)
 
 - WrapDB-compatible endpoint backed by `releases.json` and wraps.
+- `releases.json` is untrusted input: each entry is validated independently, and
+  an entry with a non-object shape or an unsafe name or version segment is
+  skipped while the rest of the repository still loads. Names and versions become
+  filesystem paths and URL segments, so unsafe segments are rejected at this
+  boundary.
 - Read-only: no publish or unpublish support.
 - HTTPS preferred; HTTP is allowed with a warning.
 
@@ -114,7 +119,7 @@ Runs Meson setup and validates `collider.json` against Meson introspection.
 
 ### `lock`
 
-Resolves dependencies from `collider.json` (including transitive dependencies) and writes `collider.lock`. Does not modify `subprojects/`; only refreshes pinned resolution state.
+Resolves dependencies from `collider.json` (including transitive dependencies) and writes `collider.lock`. Does not modify `subprojects/`; only refreshes pinned resolution state. If a package the resolver directly needs has no usable version anywhere and its repository metadata was rejected as malformed, `lock` fails closed with `EX_DATAERR` rather than resolving against corrupt data; `install` and `pkg add` apply the same check.
 
 ### `publish`
 
@@ -252,6 +257,12 @@ Searches configured repositories by name and optional version constraint.
 - `scans/` caches dependency scan results by name+version.
 - `wrapdb/` caches fetched `releases.json` per remote repository.
 - Offline mode forbids network access but allows local `file://` archives.
+- The `wraps/` and `scans/` caches are keyed by name+version only, so during
+  resolution Collider scopes reads to the repository the resolver selected: when
+  online it fetches each candidate's wrap and dependency scan from that
+  repository rather than the cache, and the name+version-keyed scan cache is
+  consulted only offline. This keeps two repositories that publish the same name
+  and version from cross-contaminating the resolved graph and the lockfile.
 
 **Rationale**
 

--- a/docs/guide/locking-and-installing.md
+++ b/docs/guide/locking-and-installing.md
@@ -105,6 +105,21 @@ incompatibilities during install:
 
 Run `collider lock` to re-resolve and clear these warnings.
 
+## Untrusted Repository Metadata
+
+A repository's `releases.json` is treated as untrusted input. Malformed
+individual entries (non-object shape, unsafe name or version segment) are skipped
+at the index boundary with a warning, and the rest of the repository still loads.
+If a package the resolver directly needs has no usable version anywhere and its
+metadata was rejected, `lock`, `install`, and `pkg add` fail closed with
+`EX_DATAERR` rather than resolving against corrupt data.
+
+When two configured repositories publish the same name and version, resolution
+reads are scoped to the repository the resolver selected: online, Collider
+fetches each candidate's wrap and dependency scan from that repository rather
+than reusing a name+version cache entry. This keeps one repository's contents
+from steering another's resolved dependency graph into `collider.lock`.
+
 ## Relationship Between Intent and Resolution
 
 | File             | Purpose                                                  |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,6 +92,14 @@ collider lock [--offline]
 |-------------|-------------------------------------------|
 | `--offline` | Resolve only from the local cache.        |
 
+A repository's `releases.json` is untrusted input. Individual malformed entries
+(non-object shape, unsafe name or version segment) are skipped at the index
+boundary with a single warning, and the rest of the repository still loads. If a
+package the resolver directly needs has no usable version anywhere and its
+metadata was rejected, `lock` refuses to write a lockfile against corrupt data
+and aborts with `EX_DATAERR`. The same fail-closed check applies to `install`
+and `pkg add`.
+
 ---
 
 ## `install`

--- a/test/repository/implementation/test_mesonwrapdb.py
+++ b/test/repository/implementation/test_mesonwrapdb.py
@@ -107,8 +107,9 @@ def test_wrap_releases_to_packages_multiple_versions():
         'foo': {'versions': ['1.0.0', '2.0.0']},
         'bar': {'versions': ['0.1.0']},
     }
-    packages = _wrap_releases_to_packages(releases)
+    packages, rejected = _wrap_releases_to_packages(releases)
     assert len(packages) == 3
+    assert rejected == []
 
     key = make_repo_key('foo', '1.0.0', PackageType.WRAP)
     entry = packages[key]
@@ -121,8 +122,9 @@ def test_wrap_releases_to_packages_empty_versions():
     releases = {
         'foo': {'versions': []},
     }
-    packages = _wrap_releases_to_packages(releases)
+    packages, rejected = _wrap_releases_to_packages(releases)
     assert packages == {}
+    assert rejected == []
 
 
 def test_wrap_releases_to_packages_skips_unsafe_name_and_version():
@@ -131,12 +133,14 @@ def test_wrap_releases_to_packages_skips_unsafe_name_and_version():
         '../../evil': {'versions': ['1.0.0']},
         'foo': {'versions': ['1.0.0', '../../evil']},
     }
-    packages = _wrap_releases_to_packages(releases)
+    packages, rejected = _wrap_releases_to_packages(releases)
 
     names = {entry.name for entry in packages.values()}
     versions = {entry.version for entry in packages.values()}
     assert names == {'foo'}
     assert versions == {'1.0.0'}
+    # Both the unsafe name and the unsafe version are recorded as rejects.
+    assert {r.reason.value for r in rejected} == {'unsafe_name', 'unsafe_version'}
 
 
 def test_wrap_url_builder_rejects_unsafe_name():

--- a/test/repository/test_entries.py
+++ b/test/repository/test_entries.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 MOG Robotics OÜ.
+
+"""Tests for releases.json indexing and its fail-soft rejection of malformed metadata."""
+
+from collider.repository.entries import RejectReason, packages_from_releases
+
+
+def test_well_formed_releases_index_without_rejects() -> None:
+    """A clean releases map indexes every version and rejects nothing."""
+    packages, rejected = packages_from_releases(
+        {'foo': {'versions': ['1.0.0', '2.0.0'], 'dependency_names': ['libfoo']}}
+    )
+    assert len(packages) == 2
+    assert rejected == []
+
+
+def test_non_dict_releases_is_rejected_not_raised() -> None:
+    """A releases.json that is not a JSON object yields no packages and a structural reject."""
+    packages, rejected = packages_from_releases(['not', 'an', 'object'])  # type: ignore[arg-type]
+    assert packages == {}
+    assert [r.reason for r in rejected] == [RejectReason.STRUCTURE]
+
+
+def test_entry_not_dict_is_rejected_individually() -> None:
+    """A single bad entry is dropped while the rest of the repo still indexes."""
+    packages, rejected = packages_from_releases(
+        {'good': {'versions': ['1.0.0']}, 'bad': 'oops'}  # type: ignore[dict-item]
+    )
+    assert {e.name for e in packages.values()} == {'good'}
+    assert len(rejected) == 1
+    assert rejected[0].name == 'bad'
+    assert rejected[0].reason is RejectReason.STRUCTURE
+
+
+def test_versions_not_list_is_structural_reject() -> None:
+    """An entry whose versions field is not a list is a structural reject, not a crash."""
+    packages, rejected = packages_from_releases({'foo': {'versions': 'oops'}})  # type: ignore[dict-item]
+    assert packages == {}
+    assert rejected[0].reason is RejectReason.STRUCTURE
+
+
+def test_unsafe_name_recorded_as_unsafe_name() -> None:
+    """A traversal name is dropped at the boundary and recorded as UNSAFE_NAME."""
+    packages, rejected = packages_from_releases({'../../evil': {'versions': ['1.0.0']}})
+    assert packages == {}
+    assert rejected[0].reason is RejectReason.UNSAFE_NAME
+
+
+def test_unsafe_version_keeps_safe_siblings() -> None:
+    """An unsafe version is dropped while safe versions of the same package survive."""
+    packages, rejected = packages_from_releases(
+        {'foo': {'versions': ['1.0.0', 'a/b'], 'dependency_names': ['libfoo']}}
+    )
+    assert {e.version for e in packages.values()} == {'1.0.0'}
+    assert rejected[0].reason is RejectReason.UNSAFE_VERSION
+
+
+def test_malformed_dep_names_do_not_crash_indexing() -> None:
+    """A non-list dependency_names is ignored for the valid entry, not indexed as provides."""
+    packages, rejected = packages_from_releases(
+        {'foo': {'versions': ['1.0.0'], 'dependency_names': 'libfoo'}}  # type: ignore[dict-item]
+    )
+    # The version still indexes; the malformed provides are simply dropped (no crash).
+    assert {e.version for e in packages.values()} == {'1.0.0'}
+    assert next(iter(packages.values())).dependency_names is None
+    assert rejected == []

--- a/test/subcommand/test_lock.py
+++ b/test/subcommand/test_lock.py
@@ -18,12 +18,13 @@ from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import LockedPackage, Lockfile, compute_wrap_hash
 from collider.Package import WrapPackage
-from collider.repository.entries import RepoPackageEntry, add_wrap_entry
+from collider.repository.entries import RejectReason, RepoPackageEntry, add_wrap_entry
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.Lock import Lock
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
+from collider.utils.packaging.resolver import MalformedRepositoryMetadata
 
 
 ORIGIN = 'https://wrapdb.example.com/v2'
@@ -112,6 +113,38 @@ def test_lock_creates_lockfile(tmp_path: Path, monkeypatch) -> None:
     assert lockfile.dependencies['shared'].wrap_hash == compute_wrap_hash(package.wrap_text)
     assert lockfile.dependencies['shared'].origin == ORIGIN
     assert not (tmp_path / 'subprojects' / 'shared.wrap').exists()
+
+
+def test_lock_fails_closed_on_malformed_metadata(tmp_path: Path) -> None:
+    """Strict resolution raising MalformedRepositoryMetadata makes lock return EX_DATAERR."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, None)],
+    )
+
+    repo = MagicMock(spec=RepositoryInterface)
+    # A package with provides flips on the transitive resolver path (use_transitive).
+    packages: dict = {}
+    add_wrap_entry(packages, 'shared', '1.0.0', ['libshared'])
+    repo.packages = packages
+    repo.requires_network.return_value = False
+    repo.origin_url = ORIGIN
+    context = _make_context(tmp_path, repo)
+
+    cmd = Lock(argparse.Namespace(offline=False), context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch(
+            'collider.subcommand.Lock.resolve_all_dependencies',
+            side_effect=MalformedRepositoryMetadata('shared', RejectReason.UNSAFE_VERSION),
+        ):
+            assert cmd.execute() == os.EX_DATAERR
+    finally:
+        os.chdir(cwd)
+
+    assert not (tmp_path / Lockfile.get_filename()).exists()
 
 
 def test_lock_rewrites_existing_lockfile(tmp_path: Path, monkeypatch) -> None:

--- a/test/utils/packaging/test_resolver.py
+++ b/test/utils/packaging/test_resolver.py
@@ -499,7 +499,7 @@ def test_provider_get_dependencies_maps_deps_to_requirements() -> None:
         repos,
         dep_index,
         scan_cache={
-            'grpc_1.0.0': scanned,
+            'grpc_1.0.0_local': scanned,
         },
     )
 
@@ -522,7 +522,7 @@ def test_provider_get_dependencies_skips_self_reference() -> None:
         repos,
         dep_index,
         scan_cache={
-            'zlib_1.3.1': scanned,
+            'zlib_1.3.1_local': scanned,
         },
     )
 
@@ -550,7 +550,7 @@ def test_provider_get_dependencies_deduplicates() -> None:
         repos,
         dep_index,
         scan_cache={
-            'grpc_1.0.0': scanned,
+            'grpc_1.0.0_local': scanned,
         },
     )
 
@@ -575,7 +575,7 @@ def test_provider_get_dependencies_passes_version_constraints() -> None:
         repos,
         dep_index,
         scan_cache={
-            'grpc_1.0.0': scanned,
+            'grpc_1.0.0_local': scanned,
         },
     )
 
@@ -599,8 +599,8 @@ def test_provider_get_dependencies_unmapped_reported_once() -> None:
         repos,
         dep_index,
         scan_cache={
-            'grpc_1.0.0': scanned,
-            'grpc_2.0.0': scanned,
+            'grpc_1.0.0_local': scanned,
+            'grpc_2.0.0_local': scanned,
         },
     )
 
@@ -627,7 +627,7 @@ def test_provider_get_dependencies_uses_scan_cache() -> None:
         repos,
         dep_index,
         scan_cache={
-            'grpc_1.0.0': scanned,
+            'grpc_1.0.0_local': scanned,
         },
     )
 
@@ -656,7 +656,7 @@ def test_provider_get_dependencies_merges_version_constraints() -> None:
         repos,
         dep_index,
         scan_cache={
-            'grpc_1.0.0': scanned,
+            'grpc_1.0.0_local': scanned,
         },
     )
 
@@ -823,7 +823,7 @@ def test_strict_get_dependencies_does_not_fail_on_unmapped_dep() -> None:
         repos,
         build_dep_name_index(repos),
         strict=True,
-        scan_cache={'foo_1.0.0': scanned},
+        scan_cache={'foo_1.0.0_local': scanned},
     )
 
     assert provider.get_dependencies(Candidate('foo', '1.0.0', 'local')) == []
@@ -1184,41 +1184,53 @@ def test_scan_candidate_online_uses_repo_get_package() -> None:
     repo.get_package.assert_called_once()
 
 
-def test_scan_candidate_online_tries_wrap_cache_before_http() -> None:
-    """In online mode, _scan_candidate checks wrap_cache before calling repo.get_package()."""
-    import hashlib
-
+def test_scan_candidate_online_fetches_from_repo_not_cache() -> None:
+    """Online, _scan_candidate fetches from the resolver-selected repo, never the
+    name+version-keyed wrap cache, so a same-versioned wrap from another repo cannot
+    contaminate the scan (and thus the locked dependency graph)."""
     from collider.cache import WrapCache
-    from collider.Package import WrapPackage
-
-    content = b'source-payload'
-    content_hash = hashlib.sha256(content).hexdigest()
 
     packages = _make_packages(('zlib', '1.3.1', ['zlib']))
     repo = _make_repo(packages, requires_network=True)
+    repo.get_package.return_value = None
     repos = {'remote': repo}
     dep_index = build_dep_name_index(repos)
 
-    cached_pkg = WrapPackage.from_wrap_text(
-        'zlib',
-        '1.3.1',
-        f'[wrap-file]\n'
-        f'source_url=https://example.com/zlib-1.3.1.tar.xz\n'
-        f'source_filename=zlib-1.3.1.tar.xz\n'
-        f'source_hash={content_hash}\n',
-    )
-
     mock_cache = MagicMock(spec=WrapCache)
-    mock_cache.load_wrap.return_value = cached_pkg
-    mock_cache.load_scan.return_value = None
 
     provider = ColliderProvider(repos, dep_index, offline=False, wrap_cache=mock_cache)
     candidate = Candidate('zlib', '1.3.1', 'remote')
 
     provider._scan_candidate(candidate)
 
-    mock_cache.load_wrap.assert_called_once_with('zlib', '1.3.1')
-    repo.get_package.assert_not_called()
+    repo.get_package.assert_called_once()
+    mock_cache.load_wrap.assert_not_called()
+
+
+def test_get_dependencies_scan_cache_is_keyed_by_repo() -> None:
+    """Two repos serving the same name+version are distinct packages, so their scans must not
+    be shared: reusing one repo's scan for the other would bake the wrong dependency graph
+    into collider.lock."""
+    packages = _make_packages(
+        ('foo', '1.0.0', ['foo']),
+        ('a', '1.0.0', ['a']),
+        ('b', '1.0.0', ['b']),
+    )
+    repos = {'repo_a': _make_repo(packages), 'repo_b': _make_repo(packages)}
+    dep_index = build_dep_name_index(repos)
+
+    provider = ColliderProvider(repos, dep_index)
+
+    def fake_scan(candidate: Candidate) -> list[ScannedDependency]:
+        dep = 'a' if candidate.repo_name == 'repo_a' else 'b'
+        return [ScannedDependency(name=dep, required=True)]
+
+    with patch.object(provider, '_scan_candidate', side_effect=fake_scan):
+        deps_a = provider.get_dependencies(Candidate('foo', '1.0.0', 'repo_a'))
+        deps_b = provider.get_dependencies(Candidate('foo', '1.0.0', 'repo_b'))
+
+    assert [d.name for d in deps_a] == ['a']
+    assert [d.name for d in deps_b] == ['b']
 
 
 def test_scan_candidate_offline_local_repo_uses_get_package() -> None:
@@ -1413,10 +1425,10 @@ def test_resolve_all_per_root_exclude_does_not_leak() -> None:
     )
 
     scan_results = {
-        'libfoo_1.0.0': [
+        'libfoo_1.0.0_local': [
             ScannedDependency(name='libcommon', required=True),
         ],
-        'libbar_1.0.0': [
+        'libbar_1.0.0_local': [
             ScannedDependency(name='libcommon', required=True),
         ],
     }
@@ -1451,10 +1463,10 @@ def test_resolve_all_per_root_include_scopes_to_root() -> None:
     )
 
     scan_results = {
-        'libfoo_1.0.0': [
+        'libfoo_1.0.0_local': [
             ScannedDependency(name='libcond', required=True, conditional=True),
         ],
-        'libbar_1.0.0': [
+        'libbar_1.0.0_local': [
             ScannedDependency(name='libcond', required=True, conditional=True),
         ],
     }
@@ -1468,7 +1480,9 @@ def test_resolve_all_per_root_include_scopes_to_root() -> None:
 
 
 def test_get_dependencies_uses_persistent_scan_cache() -> None:
-    """get_dependencies loads from persistent scan cache, skipping _scan_candidate."""
+    """Offline, get_dependencies loads from the persistent scan cache, skipping _scan_candidate.
+    The disk scan cache is name+version-keyed, so it is trusted only offline (online always
+    rescans the resolver-selected repo to avoid cross-origin contamination)."""
     from collider.cache import WrapCache
 
     packages = _make_packages(
@@ -1484,7 +1498,7 @@ def test_get_dependencies_uses_persistent_scan_cache() -> None:
     mock_cache = MagicMock(spec=WrapCache)
     mock_cache.load_scan.return_value = cached_scan
 
-    provider = ColliderProvider(repos, dep_index, wrap_cache=mock_cache)
+    provider = ColliderProvider(repos, dep_index, offline=True, wrap_cache=mock_cache)
     candidate = Candidate('grpc', '1.0.0', 'local')
 
     with patch.object(provider, '_scan_candidate') as mock_scan:
@@ -1570,9 +1584,9 @@ def test_scan_candidate_uses_persistent_archive_cache(tmp_path: Path) -> None:
 
     mock_cache = MagicMock(spec=WrapCache)
     mock_cache.load_wrap.return_value = cached_pkg
-    mock_cache.load_scan.return_value = None
 
-    provider = ColliderProvider(repos, dep_index, offline=False, wrap_cache=mock_cache)
+    # Offline, _scan_candidate loads the cached wrap and stages its archive via wrap_cache.
+    provider = ColliderProvider(repos, dep_index, offline=True, wrap_cache=mock_cache)
     candidate = Candidate('zlib', '1.3.1', 'remote')
 
     provider._scan_candidate(candidate)

--- a/test/utils/packaging/test_resolver.py
+++ b/test/utils/packaging/test_resolver.py
@@ -12,12 +12,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 import resolvelib
 
-from collider.repository.entries import RepoPackageEntry, add_wrap_entry
+from collider.repository.entries import (
+    RejectedEntry,
+    RejectReason,
+    RepoPackageEntry,
+    add_wrap_entry,
+)
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.utils.meson.scan import ScannedDependency, filter_dependencies
 from collider.utils.packaging.resolver import (
     Candidate,
     ColliderProvider,
+    MalformedRepositoryMetadata,
     Requirement,
     ResolutionSummary,
     RootSpec,
@@ -25,6 +31,7 @@ from collider.utils.packaging.resolver import (
     _group_by_package,
     _ProgressReporter,
     build_dep_name_index,
+    build_rejected_name_index,
     resolve_all_dependencies,
     resolve_dependencies,
 )
@@ -706,6 +713,121 @@ def test_resolve_passes_offline_to_provider() -> None:
 
     assert len(captured_provider) == 1
     assert captured_provider[0].offline is True
+
+
+def test_resolve_passes_strict_to_provider() -> None:
+    """resolve_dependencies forwards the strict flag to ColliderProvider."""
+    packages = _make_packages(('zlib', '1.3.1', ['zlib']))
+    repo = _make_repo(packages)
+    repos = {'local': repo}
+
+    captured_provider: list[ColliderProvider] = []
+    original_init = ColliderProvider.__init__
+
+    def capturing_init(self_prov, *args, **kwargs):
+        original_init(self_prov, *args, **kwargs)
+        captured_provider.append(self_prov)
+
+    with (
+        patch(
+            'collider.utils.packaging.resolver.ColliderProvider.get_dependencies',
+            return_value=[],
+        ),
+        patch.object(ColliderProvider, '__init__', capturing_init),
+    ):
+        resolve_dependencies(root_name='zlib', root_version_spec=None, repos=repos, strict=True)
+
+    assert captured_provider[0].strict is True
+
+
+# -- strict-mode metadata rejection -------------------------------------------
+
+
+def _rejected(name, reason):
+    """Build a RejectedEntry for tests."""
+    return RejectedEntry(name=name, reason=reason)
+
+
+def test_rejected_name_index_collects_by_name() -> None:
+    """build_rejected_name_index keys rejects by package name."""
+    repo = _make_repo({})
+    repo.rejected_metadata = [_rejected('foo', RejectReason.UNSAFE_VERSION)]
+    index = build_rejected_name_index({'local': repo})
+    assert index['foo'].reason is RejectReason.UNSAFE_VERSION
+
+
+def test_strict_find_matches_raises_when_only_rejected() -> None:
+    """A needed root with no valid versions and a rejected entry fails closed in strict mode."""
+    repo = _make_repo({})  # No usable packages for 'foo'.
+    repo.rejected_metadata = [_rejected('foo', RejectReason.UNSAFE_VERSION)]
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos), strict=True)
+
+    req = Requirement('foo')
+    with pytest.raises(MalformedRepositoryMetadata):
+        list(
+            provider.find_matches(
+                identifier='foo',
+                requirements={'foo': [req]},
+                incompatibilities={'foo': []},
+            )
+        )
+
+
+def test_strict_find_matches_tolerates_rejected_sibling() -> None:
+    """A valid version alongside a rejected sibling still resolves: no shared-infra DoS."""
+    packages = _make_packages(('foo', '1.0.0', ['foo']))
+    repo = _make_repo(packages)
+    repo.rejected_metadata = [_rejected('foo', RejectReason.UNSAFE_VERSION)]
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos), strict=True)
+
+    req = Requirement('foo')
+    matches = list(
+        provider.find_matches(
+            identifier='foo', requirements={'foo': [req]}, incompatibilities={'foo': []}
+        )
+    )
+    assert [m.version for m in matches] == ['1.0.0']
+
+
+def test_tolerant_find_matches_never_raises_on_rejected() -> None:
+    """Without strict, a rejected-only package just returns no candidates (search stays tolerant)."""
+    repo = _make_repo({})
+    repo.rejected_metadata = [_rejected('foo', RejectReason.UNSAFE_VERSION)]
+    repos = {'local': repo}
+    provider = ColliderProvider(repos, build_dep_name_index(repos))  # strict defaults to False.
+
+    matches = list(
+        provider.find_matches(
+            identifier='foo',
+            requirements={'foo': [Requirement('foo')]},
+            incompatibilities={'foo': []},
+        )
+    )
+    assert matches == []
+
+
+def test_strict_get_dependencies_does_not_fail_on_unmapped_dep() -> None:
+    """An unmapped dependency() name is indistinguishable from a system dep: strict must NOT fail.
+
+    Keying fail-closed on an unmapped name would let a forged "provides" claim for a common system
+    library (e.g. threads/dl/m) brick every project, so strict mode deliberately demotes it to a
+    system dependency just like tolerant mode.
+    """
+    repo = _make_repo({})
+    repo.rejected_metadata = [_rejected('bar', RejectReason.UNSAFE_VERSION)]
+    repos = {'local': repo}
+    scanned = [ScannedDependency(name='libbar', required=True)]
+    provider = ColliderProvider(
+        repos,
+        build_dep_name_index(repos),
+        strict=True,
+        scan_cache={'foo_1.0.0': scanned},
+    )
+
+    assert provider.get_dependencies(Candidate('foo', '1.0.0', 'local')) == []
+    assert 'libbar' in provider.all_unmapped
 
 
 # -- _extract_archive ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardens how Collider consumes untrusted repository metadata, on two fronts plus docs.

**Fail closed on malformed `releases.json` (`feat`).** The index parser
(`packages_from_releases`) is now total: a malformed individual entry (non-object
shape, unsafe name or version segment, non-list versions) is skipped and recorded
rather than raising. Previously a single bad entry raised and was swallowed by the
command-agnostic repository loader, silently dropping the **whole** repository.
`lock`, `install`, and `pkg add` now resolve in strict mode: when a package they
directly need has no usable version anywhere and its metadata was rejected,
resolution raises `MalformedRepositoryMetadata` and the command exits `EX_DATAERR`
instead of resolving against corrupt data. `pkg search` and `status` stay tolerant.
The guard keys only on package names, never on an entry's self-declared
`dependency_names`, so forged provides cannot fail-close a victim's build.

**Isolate wrap-cache reads by origin during resolution (`fix`).** The wrap cache
is keyed by name+version only, and resolution read it while discarding the
resolver-selected repository. When two configured repositories serve the same
name+version with different contents, an online `collider lock` could compute one
package's dependency graph from the other repository's cached wrap or scan and bake
the wrong edge set into `collider.lock`, which later installs then reproduce
verifiably. Resolution now keys the in-memory scan cache by repository, consults
the name+version-keyed disk scan cache only offline, and fetches the wrap from the
resolver-selected repository when online.

**Docs.** Documents the untrusted-`releases.json` handling and origin-scoped
resolution in the design doc, the lock/install guide, and the CLI reference.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.
