### PR TITLE
chore: address Codacy review on #72

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,9 @@
+---
+# Bandit reports pytest's `assert` statements as B101 ("assert detected"), which it
+# ranks as a high-severity security finding. Asserts are the expected idiom in tests,
+# so exclude the test tree from Bandit while keeping every other Codacy engine active
+# on it.
+engines:
+  bandit:
+    exclude_paths:
+      - 'test/**'

--- a/collider/subcommand/Install.py
+++ b/collider/subcommand/Install.py
@@ -254,8 +254,7 @@ class Install(SubcommandInterface):
                     exclude_optional=any(dep.exclude_optional for dep in collider_deps),
                 )
             except MalformedRepositoryMetadata as e:
-                logger.critical(f'Refusing to install against malformed repository metadata: {e}')
-                return os.EX_DATAERR
+                return self._reject_malformed_metadata(e, 'install')
             except (
                 resolvelib.RequirementsConflicted,
                 resolvelib.ResolutionImpossible,

--- a/collider/subcommand/Lock.py
+++ b/collider/subcommand/Lock.py
@@ -123,8 +123,7 @@ class Lock(InstallSubcommand):
                     exclude_optional=any(dep.exclude_optional for dep in collider_deps),
                 )
             except MalformedRepositoryMetadata as e:
-                logger.critical(f'Refusing to lock against malformed repository metadata: {e}')
-                return os.EX_DATAERR
+                return self._reject_malformed_metadata(e, 'lock')
             except (
                 resolvelib.RequirementsConflicted,
                 resolvelib.ResolutionImpossible,

--- a/collider/subcommand/SubcommandInterface.py
+++ b/collider/subcommand/SubcommandInterface.py
@@ -6,11 +6,13 @@
 from __future__ import annotations
 
 import argparse
+import os
 
 from abc import ABC, abstractmethod
 from typing import Optional
 
 from collider.Context import Context
+from collider.log import logger
 
 
 class SubcommandInterface(ABC):
@@ -48,3 +50,14 @@ class SubcommandInterface(ABC):
     @abstractmethod
     def execute(self) -> int:
         """Process exit code for the CLI to propagate."""
+
+    @staticmethod
+    def _reject_malformed_metadata(exc: Exception, action: str) -> int:
+        """
+        Log a refusal to act on malformed repository metadata and return the data-error code.
+        :param exc: The raised malformed-metadata error.
+        :param action: Verb describing the refused action, e.g. "lock" or "install".
+        :return: The data-error exit code.
+        """
+        logger.critical(f'Refusing to {action} against malformed repository metadata: {exc}')
+        return os.EX_DATAERR

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -491,8 +491,7 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
                 exclude_names=exclude_set,
             )
         except MalformedRepositoryMetadata as e:
-            logger.critical(f'Refusing to install against malformed repository metadata: {e}')
-            return os.EX_DATAERR
+            return self._reject_malformed_metadata(e, 'install')
         except (
             resolvelib.RequirementsConflicted,
             resolvelib.ResolutionImpossible,

--- a/test/subcommand/test_install.py
+++ b/test/subcommand/test_install.py
@@ -20,12 +20,13 @@ from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile, compute_wrap_hash
 from collider.Package import WrapPackage
-from collider.repository.entries import RepoPackageEntry
+from collider.repository.entries import RejectReason, RepoPackageEntry, add_wrap_entry
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.pkg.Add import Add
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from collider.utils.packaging.PackageType import PackageType
 from collider.utils.packaging.repo_key import make_repo_key
+from collider.utils.packaging.resolver import MalformedRepositoryMetadata
 
 
 ORIGIN = 'https://wrapdb.example.com/v2/'
@@ -552,3 +553,55 @@ def test_install_adds_dependency_without_version(tmp_path: Path, monkeypatch) ->
     assert len(colliderfile.dependencies) == 1
     assert colliderfile.dependencies[0].name == 'shared'
     assert colliderfile.dependencies[0].version is None
+
+
+def test_install_fails_closed_on_malformed_metadata(tmp_path: Path) -> None:
+    """A lockless install whose strict resolution raises MalformedRepositoryMetadata returns
+    EX_DATAERR rather than resolving against corrupt repository metadata."""
+    from collider.subcommand.Install import Install
+
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, None)],
+    )
+
+    repo = MagicMock(spec=RepositoryInterface)
+    packages: dict = {}
+    # A package with provides flips on the transitive resolver path (use_transitive).
+    add_wrap_entry(packages, 'shared', '1.0.0', ['libshared'])
+    repo.packages = packages
+    repo.requires_network.return_value = False
+    context = _make_context(tmp_path, repo)
+
+    cmd = Install(argparse.Namespace(offline=False), context)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch(
+            'collider.subcommand.Install.resolve_all_dependencies',
+            side_effect=MalformedRepositoryMetadata('shared', RejectReason.UNSAFE_VERSION),
+        ):
+            assert cmd.execute() == os.EX_DATAERR
+    finally:
+        os.chdir(cwd)
+
+
+def test_add_fails_closed_on_malformed_metadata(tmp_path: Path) -> None:
+    """Strict transitive resolution raising MalformedRepositoryMetadata makes pkg add return
+    EX_DATAERR rather than resolving against corrupt repository metadata."""
+    repo = MagicMock(spec=RepositoryInterface)
+    packages: dict = {}
+    # A package with provides keeps the dependency-name index non-empty so resolution runs.
+    add_wrap_entry(packages, 'libshared', '1.0.0', ['libshared'])
+    repo.packages = packages
+    repo.requires_network.return_value = False
+    context = _make_context(tmp_path, repo)
+
+    cmd = Add(argparse.Namespace(package='shared', offline=False), context)
+
+    with patch(
+        'collider.subcommand.pkg.Add.resolve_dependencies',
+        side_effect=MalformedRepositoryMetadata('shared', RejectReason.UNSAFE_VERSION),
+    ):
+        assert cmd._resolve_and_install_transitive({'repo1': repo}) == os.EX_DATAERR

--- a/test/utils/packaging/test_resolver.py
+++ b/test/utils/packaging/test_resolver.py
@@ -15,7 +15,6 @@ import resolvelib
 from collider.repository.entries import (
     RejectedEntry,
     RejectReason,
-    RepoPackageEntry,
     add_wrap_entry,
 )
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface


### PR DESCRIPTION
## Summary

Follow-up addressing the Codacy review on #72.

- **Centralize the malformed-metadata refusal.** Codacy flagged the
  `except MalformedRepositoryMetadata` block (log critical + return `EX_DATAERR`)
  as duplicated across `lock`, `install`, and `pkg add`. Extracted into a single
  `_reject_malformed_metadata` helper on the subcommand base; the action verb
  keeps each message intact. No behavior change.
- **Cover the untested fail-closed paths.** `install` (lockless) and `pkg add`
  now have regression tests asserting `EX_DATAERR` when strict resolution raises
  `MalformedRepositoryMetadata`, matching the existing `lock` coverage.
- **Drop an unused import.** The resolver-test rewrite in #72 left an unused
  `RepoPackageEntry` import; this project's ruff config checks only import
  sorting (`lint.select = ["I"]`), not unused imports, so it slipped through.
- **Quiet the Bandit assert noise.** Codacy reported 14 "high security" issues
  that are all Bandit B101 (`assert` detected) in test files. Added `.codacy.yaml`
  excluding the test tree from Bandit, since `assert` is the expected idiom in
  pytest; other Codacy engines still analyze tests.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.
