### PR TITLE
chore: release 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "collider-wraps"
-version = "1.4.0.dev0"
+version = "1.4.0"
 description = "A package and dependency manager for Meson projects."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "collider-wraps"
-version = "1.4.0.dev0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

Finalize the `1.4.0` release: bump `version` from `1.4.0.dev0` to `1.4.0`.

Notable changes since `1.3.0`:
- `feat(publish)`: require HTTPS for the authenticated token push (`--insecure` override) (#68)
- `feat(setup)`: fail on wrap drift from `collider.lock`, add `--allow-drift` (#70)
- `feat(repository)`: fail closed on malformed `releases.json` metadata (#72)
- `fix(resolver)`: isolate wrap-cache reads by origin during resolution (#72)
- Docs, tests, and Codacy follow-up cleanup (#71, #73)

Tagging `1.4.0` after merge triggers the publish workflow.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (release: version bump to 1.4.0)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.
