### PR TITLE
fix(remove): delete the wrap's extracted tree, not subprojects/<name>

### DIFF
--- a/collider/Package.py
+++ b/collider/Package.py
@@ -60,6 +60,24 @@ def get_provide_names(wrap_text: str) -> list[str]:
     return sorted(names)
 
 
+def read_wrap_directory(wrap_text: str) -> Optional[str]:
+    """
+    Return the subproject directory a wrap extracts into, or None when it is unset.
+    Meson reads ``directory`` from the wrap's ``[wrap-file]`` or ``[wrap-git]`` section and
+    otherwise defaults to the wrap filename stem; a blank value is treated as unset. The value
+    is returned verbatim and is NOT validated as a safe path segment.
+    :param wrap_text: Raw wrap file contents.
+    :return: The declared directory name, or None when absent or blank.
+    """
+    parser = _parse_wrap(wrap_text)
+    for kind in ('wrap-file', 'wrap-git'):
+        if parser.has_section(kind):
+            value = parser[kind].get('directory', '').strip()
+            if value:
+                return value
+    return None
+
+
 @dataclass(frozen=True)
 class WrapPackage:  # pylint: disable=too-many-instance-attributes
     """Wrap metadata required to resolve and cache Meson dependencies."""

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -14,9 +14,14 @@ from typing import Optional
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile, compute_wrap_hash
 from collider.log import logger
-from collider.Package import get_provide_names
+from collider.Package import get_provide_names, read_wrap_directory
+from collider.utils.core import is_safe_path_segment
 from collider.utils.meson import SUBPROJECTS_DIR
 from collider.utils.packaging.Dependency import Dependency, DependencySource
+
+
+# Meson's shared download cache lives under subprojects/; it is never a package's extracted tree.
+_RESERVED_SUBPROJECT_DIRS = frozenset({'packagecache'})
 
 
 def load_colliderfile() -> Colliderfile:
@@ -60,21 +65,88 @@ def update_collider_dependency_version(
     return True
 
 
+def _declared_subproject_dir(wrap_path: Path, package_name: str) -> Optional[str]:
+    """
+    Return the extracted subproject directory a wrap declares via ``directory=``, or None.
+    Meson extracts a wrap into its ``directory`` field (for collider/WrapDB wraps usually
+    ``<name>-<version>``), not necessarily ``<package_name>``. Returns None when the wrap is
+    absent, unreadable, declares no directory, or declares one that is unsafe or reserved, so
+    the caller never deletes an unexpected path.
+    :param wrap_path: Path to the package's .wrap file.
+    :param package_name: Package whose artifacts are being removed (for messages).
+    :return: A safe directory name to remove, or None.
+    """
+    try:
+        declared = read_wrap_directory(wrap_path.read_text(encoding='utf-8'))
+    except (OSError, UnicodeDecodeError, configparser.Error) as exc:
+        logger.debug(f'Cannot read wrap "{wrap_path}" to resolve its directory: {exc}')
+        return None
+    if declared is None:
+        return None
+    if not is_safe_path_segment(declared):
+        logger.warning(
+            f'Wrap for "{package_name}" declares an unsafe subproject directory '
+            f'"{declared}"; leaving it in place. Remove it manually if needed.'
+        )
+        return None
+    return declared
+
+
+def _remove_subproject_tree(subprojects_dir: Path, name: str) -> bool:
+    """
+    Remove a single extracted subproject directory and report whether anything was removed.
+    ``name`` is a safe single path segment, so the target is always a direct child of
+    subprojects/; the shared packagecache is never touched, and a symlink or file is unlinked
+    rather than followed into.
+    :param subprojects_dir: The project's subprojects/ directory.
+    :param name: Safe single-segment directory name to remove.
+    :return: True when something was removed.
+    """
+    if name in _RESERVED_SUBPROJECT_DIRS:
+        logger.debug(f'Preserving reserved subproject directory "{name}".')
+        return False
+    target = subprojects_dir / name
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+        return True
+    if target.is_dir():
+        shutil.rmtree(target)
+        return True
+    return False
+
+
 def remove_installed_artifacts(package_name: str) -> bool:
-    """Remove installed wrap state from subprojects/ for a package."""
+    """
+    Remove a package's installed wrap state: the .wrap descriptor and any extracted source tree.
+    Meson extracts into the wrap's ``directory=`` field, so both that target and the legacy
+    ``<package_name>`` directory are cleared (they collapse to one path when equal); clearing the
+    legacy directory also keeps a later reinstall from tripping on a stale tree. Names are
+    validated as safe single path segments first, so an irreversible delete can never escape
+    subprojects/.
+    :param package_name: Collider-managed package to remove.
+    :return: True when any artifact was removed.
+    """
+    if not is_safe_path_segment(package_name):
+        logger.warning(f'Refusing to remove artifacts for unsafe package name "{package_name}".')
+        return False
+
+    subprojects_dir = Path.cwd() / SUBPROJECTS_DIR
+    wrap_path = subprojects_dir / f'{package_name}.wrap'
+
+    # Resolve the extracted directory from the wrap before unlinking it.
+    declared_dir = _declared_subproject_dir(wrap_path, package_name)
+
     removed_any = False
-    wrap_path = Path.cwd() / SUBPROJECTS_DIR / f'{package_name}.wrap'
     if wrap_path.exists() or wrap_path.is_symlink():
         wrap_path.unlink()
         removed_any = True
 
-    subproject_dir = Path.cwd() / SUBPROJECTS_DIR / package_name
-    if subproject_dir.is_symlink() or subproject_dir.is_file():
-        subproject_dir.unlink()
-        removed_any = True
-    elif subproject_dir.is_dir():
-        shutil.rmtree(subproject_dir)
-        removed_any = True
+    dir_names = [package_name]
+    if declared_dir is not None and declared_dir != package_name:
+        dir_names.append(declared_dir)
+    for name in dir_names:
+        if _remove_subproject_tree(subprojects_dir, name):
+            removed_any = True
 
     return removed_any
 

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -70,8 +70,8 @@ def _declared_subproject_dir(wrap_path: Path, package_name: str) -> Optional[str
     Return the extracted subproject directory a wrap declares via ``directory=``, or None.
     Meson extracts a wrap into its ``directory`` field (for collider/WrapDB wraps usually
     ``<name>-<version>``), not necessarily ``<package_name>``. Returns None when the wrap is
-    absent, unreadable, declares no directory, or declares one that is unsafe or reserved, so
-    the caller never deletes an unexpected path.
+    absent, unreadable, declares no directory, or declares one that is not a safe path segment,
+    so the caller never deletes an unexpected path.
     :param wrap_path: Path to the package's .wrap file.
     :param package_name: Package whose artifacts are being removed (for messages).
     :return: A safe directory name to remove, or None.
@@ -102,7 +102,10 @@ def _remove_subproject_tree(subprojects_dir: Path, name: str) -> bool:
     :param name: Safe single-segment directory name to remove.
     :return: True when something was removed.
     """
-    if name in _RESERVED_SUBPROJECT_DIRS:
+    # Compare case-insensitively and ignore trailing dots/spaces so a wrap cannot dodge the
+    # guard with `directory=PackageCache` on a case-insensitive filesystem (macOS/Windows) or a
+    # Windows trailing-dot variant, where that path is still the shared packagecache.
+    if name.strip(' .').casefold() in _RESERVED_SUBPROJECT_DIRS:
         logger.debug(f'Preserving reserved subproject directory "{name}".')
         return False
     target = subprojects_dir / name

--- a/docs/guide/managing-packages.md
+++ b/docs/guide/managing-packages.md
@@ -109,7 +109,10 @@ works.
 `pkg remove` is conservative about installed artifacts. If another dependency
 still requires the package transitively, Collider keeps the wrap in place. If
 Collider cannot determine safely whether the package is still needed, it also
-leaves the wrap in place and warns instead of deleting it.
+leaves the wrap in place and warns instead of deleting it. When it does remove a
+package, it deletes both the `.wrap` descriptor and the extracted source tree
+under `subprojects/`, so an obsolete source tree cannot keep satisfying a Meson
+`dependency()` after removal.
 
 If the package is still present in `collider.lock`, Collider warns you to run
 `collider lock` to update the lockfile.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -257,7 +257,10 @@ Fails if the package is already installed unless `--force` is given. If the wrap
 
 Remove a dependency from `collider.json`. Collider removes the installed wrap
 only when it can prove the package is no longer needed; otherwise it leaves
-the wrap in place.
+the wrap in place. When it does remove a package, it deletes both the `.wrap`
+descriptor and the extracted source tree under `subprojects/` (the directory the
+wrap declares via `directory=`, plus the legacy `<name>` directory), so a stale
+tree cannot later satisfy a Meson `dependency()`.
 
 ```bash
 collider pkg remove <name>

--- a/test/package/test_package.py
+++ b/test/package/test_package.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from collider.Package import WrapPackage, get_provide_names
+from collider.Package import WrapPackage, get_provide_names, read_wrap_directory
 
 
 def test_wrap_package_install_writes_wrap_file(tmp_path: Path):
@@ -129,3 +129,25 @@ def test_get_provide_names_reads_git_wrap_provide():
 
 def test_get_provide_names_without_provide_section_returns_empty():
     assert get_provide_names('[wrap-git]\nurl=https://example.invalid/foo.git\n') == []
+
+
+def test_read_wrap_directory_from_wrap_file():
+    text = '[wrap-file]\ndirectory = fmt-10.0.0\nsource_url = https://x/y.tar.gz\n'
+    assert read_wrap_directory(text) == 'fmt-10.0.0'
+
+
+def test_read_wrap_directory_from_wrap_git():
+    text = '[wrap-git]\ndirectory = mydep-src\nurl = https://example.invalid/mydep.git\n'
+    assert read_wrap_directory(text) == 'mydep-src'
+
+
+def test_read_wrap_directory_blank_is_none():
+    assert read_wrap_directory('[wrap-file]\ndirectory =   \nsource_url = https://x/y\n') is None
+
+
+def test_read_wrap_directory_absent_is_none():
+    assert read_wrap_directory('[wrap-file]\nsource_url = https://x/y.tar.gz\n') is None
+
+
+def test_read_wrap_directory_redirect_is_none():
+    assert read_wrap_directory('[wrap-redirect]\nfilename = subprojects/other.wrap\n') is None

--- a/test/utils/test_project_state.py
+++ b/test/utils/test_project_state.py
@@ -311,6 +311,32 @@ def test_remove_artifacts_never_deletes_packagecache(tmp_path: Path, monkeypatch
     assert (pkgcache / 'shared.tar.gz').exists()
 
 
+def test_remove_artifacts_packagecache_guard_is_case_insensitive(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`directory = PackageCache` must not wipe the cache on a case-insensitive filesystem."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'evil', _wrap_file_text('PackageCache'))
+    pkgcache = subprojects / 'packagecache'
+    pkgcache.mkdir()
+    (pkgcache / 'shared.tar.gz').write_text('archive', encoding='utf-8')
+
+    assert remove_installed_artifacts('evil') is True
+    assert (pkgcache / 'shared.tar.gz').exists()
+
+
+def test_remove_artifacts_directory_equals_name(tmp_path: Path, monkeypatch) -> None:
+    """When `directory=` equals the package name the tree is removed once, not twice."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'foo', _wrap_file_text('foo'))
+    (subprojects / 'foo').mkdir()
+
+    assert remove_installed_artifacts('foo') is True
+    assert not (subprojects / 'foo').exists()
+
+
 def test_remove_artifacts_refuses_unsafe_directory(tmp_path: Path, monkeypatch) -> None:
     """An unsafe `directory=` (path traversal) deletes nothing outside subprojects/."""
     monkeypatch.chdir(tmp_path)

--- a/test/utils/test_project_state.py
+++ b/test/utils/test_project_state.py
@@ -14,6 +14,7 @@ from collider.utils.project_state import (
     collect_force_fallback_names,
     detect_locked_wrap_drift,
     managed_package_names,
+    remove_installed_artifacts,
 )
 
 
@@ -233,3 +234,143 @@ def test_drift_raises_on_malformed_lock(tmp_path: Path) -> None:
     (tmp_path / Lockfile.get_filename()).write_text('{ not valid json', encoding='utf-8')
     with pytest.raises(ValueError, match='malformed'):
         detect_locked_wrap_drift(tmp_path)
+
+
+# -- remove_installed_artifacts (#45) -----------------------------------------
+
+
+def _absent_directory_wrap() -> str:
+    """A [wrap-file] with no `directory` key, so Meson defaults to the wrap stem."""
+    return (
+        '[wrap-file]\n'
+        'source_url = https://example.invalid/x.tar.gz\n'
+        'source_filename = x.tar.gz\n'
+        f'source_hash = {"0" * 64}\n'
+    )
+
+
+def test_remove_artifacts_deletes_directory_field_tree(tmp_path: Path, monkeypatch) -> None:
+    """The extracted tree named by `directory=` (not <name>) is removed."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'fmt', _wrap_file_text('fmt-10.0.0'))
+    tree = subprojects / 'fmt-10.0.0'
+    tree.mkdir()
+    (tree / 'meson.build').write_text('project()', encoding='utf-8')
+
+    assert remove_installed_artifacts('fmt') is True
+    assert not (subprojects / 'fmt.wrap').exists()
+    assert not tree.exists()
+
+
+def test_remove_artifacts_clears_legacy_and_directory_field(tmp_path: Path, monkeypatch) -> None:
+    """Both the legacy <name> dir and the `directory=` target are removed when both exist."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'fmt', _wrap_file_text('fmt-10.0.0'))
+    (subprojects / 'fmt').mkdir()
+    (subprojects / 'fmt-10.0.0').mkdir()
+
+    assert remove_installed_artifacts('fmt') is True
+    assert not (subprojects / 'fmt').exists()
+    assert not (subprojects / 'fmt-10.0.0').exists()
+
+
+def test_remove_artifacts_absent_directory_uses_name(tmp_path: Path, monkeypatch) -> None:
+    """With no `directory=`, the <name> tree (Meson's default) is removed."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'foo', _absent_directory_wrap())
+    (subprojects / 'foo').mkdir()
+
+    assert remove_installed_artifacts('foo') is True
+    assert not (subprojects / 'foo').exists()
+
+
+def test_remove_artifacts_blank_directory_falls_back(tmp_path: Path, monkeypatch) -> None:
+    """A blank `directory=` is treated as absent, falling back to the <name> tree."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'foo', _wrap_file_text(''))
+    (subprojects / 'foo').mkdir()
+
+    assert remove_installed_artifacts('foo') is True
+    assert not (subprojects / 'foo').exists()
+
+
+def test_remove_artifacts_never_deletes_packagecache(tmp_path: Path, monkeypatch) -> None:
+    """A wrap declaring `directory = packagecache` must not delete the shared archive cache."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'evil', _wrap_file_text('packagecache'))
+    pkgcache = subprojects / 'packagecache'
+    pkgcache.mkdir()
+    (pkgcache / 'shared.tar.gz').write_text('archive', encoding='utf-8')
+
+    assert remove_installed_artifacts('evil') is True  # the .wrap is still removed
+    assert (pkgcache / 'shared.tar.gz').exists()
+
+
+def test_remove_artifacts_refuses_unsafe_directory(tmp_path: Path, monkeypatch) -> None:
+    """An unsafe `directory=` (path traversal) deletes nothing outside subprojects/."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'foo', _wrap_file_text('../evil'))
+    outside = tmp_path / 'evil'
+    outside.mkdir()
+    (outside / 'keep.txt').write_text('precious', encoding='utf-8')
+
+    assert remove_installed_artifacts('foo') is True  # the .wrap is still removed
+    assert (outside / 'keep.txt').exists()
+
+
+def test_remove_artifacts_refuses_unsafe_package_name(tmp_path: Path, monkeypatch) -> None:
+    """An unsafe package name (path traversal) deletes nothing outside subprojects/."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'subprojects').mkdir()
+    victim_wrap = tmp_path / 'victim.wrap'
+    victim_wrap.write_text('precious', encoding='utf-8')
+    victim_dir = tmp_path / 'victim'
+    victim_dir.mkdir()
+    (victim_dir / 'keep.txt').write_text('precious', encoding='utf-8')
+
+    assert remove_installed_artifacts('../victim') is False
+    assert victim_wrap.exists()
+    assert (victim_dir / 'keep.txt').exists()
+
+
+def test_remove_artifacts_unlinks_symlink_without_following(tmp_path: Path, monkeypatch) -> None:
+    """A symlinked subproject target is unlinked, never rmtree'd through."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    _write_wrap(subprojects, 'foo', _wrap_file_text('foo-1.0'))
+    real = tmp_path / 'real_tree'
+    real.mkdir()
+    (real / 'keep.txt').write_text('precious', encoding='utf-8')
+    link = subprojects / 'foo-1.0'
+    link.symlink_to(real, target_is_directory=True)
+
+    assert remove_installed_artifacts('foo') is True
+    assert not link.is_symlink()
+    assert (real / 'keep.txt').exists()
+
+
+def test_remove_artifacts_falls_back_when_wrap_unreadable(tmp_path: Path, monkeypatch) -> None:
+    """An unparseable wrap falls back to the <name> tree rather than crashing."""
+    monkeypatch.chdir(tmp_path)
+    subprojects = tmp_path / 'subprojects'
+    subprojects.mkdir(parents=True)
+    (subprojects / 'foo.wrap').write_text('not a valid ini {{{', encoding='utf-8')
+    (subprojects / 'foo').mkdir()
+
+    assert remove_installed_artifacts('foo') is True
+    assert not (subprojects / 'foo').exists()
+    assert not (subprojects / 'foo.wrap').exists()
+
+
+def test_remove_artifacts_returns_false_when_nothing_present(tmp_path: Path, monkeypatch) -> None:
+    """Removing a package with no wrap and no tree reports that nothing was removed."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / 'subprojects').mkdir()
+
+    assert remove_installed_artifacts('absent') is False


### PR DESCRIPTION
## Summary

Fixes #45: `collider pkg remove` (and `pkg upgrade`/`--force` reinstall) deleted
`subprojects/<package_name>`, but Meson extracts a wrap into the directory named
by its `directory=` field (for collider/WrapDB wraps usually `<name>-<version>`,
e.g. `subprojects/cxxopts-3.2.0/`). So the extracted source tree survived every
remove while the command printed success, and the stale tree could later satisfy
a `dependency()` and silently mask the removal.

`remove_installed_artifacts` now reads the wrap's `directory=` (new public
`read_wrap_directory` helper in `Package.py`) **before** unlinking the `.wrap`,
and removes both that target and the legacy `<package_name>` directory (clearing
the legacy one also keeps a later reinstall from tripping on a stale tree, which
would otherwise raise `FileExistsError`).

### Safety (this is an irreversible `rmtree`)
- Package and `directory=` names must be safe single path segments, so the target
  is provably a direct child of `subprojects/` and the delete cannot escape it.
- The shared `subprojects/packagecache` is never removed (a `directory=packagecache`
  would otherwise wipe every package's cached archives).
- A symlinked target is unlinked, never followed into.
- An unreadable/malformed or `directory=`-less wrap falls back to `<package_name>`.

The design and implementation were both hardened by an adversarial review (which
caught the `packagecache`-wipe case and a path-traversal escape before merge).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.
