### PR TITLE
docs: reposition Collider as extending Meson wrap ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,21 @@
   <a href="https://matrix.to/#/#collider:matrix.org"><img src="https://img.shields.io/badge/Join%20chat-%23collider%3Amatrix.org-000000?logo=matrix" alt="Matrix"></a>
 </p>
 
-Collider is a dependency manager for Meson projects.
+<p align="center"><b>Collider brings modern package management to Meson's native wrap ecosystem.</b></p>
 
-It also provides the infrastructure to run private WrapDB-compatible
-package repositories, enabling teams to build their own package ecosystem.
+Rather than replacing Meson's dependency model, Collider extends it:
+automatic dependency resolution, lockfiles, and a streamlined day-to-day
+workflow, fully compatible with wraps and WrapDB.
+
+It also lets teams run private WrapDB-compatible package repositories and
+publish to them, so you can build your own package ecosystem on the same
+infrastructure Meson already understands.
 
 **Documentation: [collider.ee](https://collider.ee)**
 
 ## Features
 
-- Dependency manager for Meson wrap projects.
+- Automatic dependency resolution for Meson wrap projects.
 - Publishable wrap repositories.
 - Host your own WrapDB-compatible package repository.
 - Lockfiles for reproducible builds.

--- a/collider/entrypoint.py
+++ b/collider/entrypoint.py
@@ -121,7 +121,7 @@ def main() -> int:
 
     parser = argparse.ArgumentParser(
         prog=collider.__name__,
-        description='A package and dependency manager for Meson projects.',
+        description="Modern package management for Meson's wrap ecosystem.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         add_help=False,
     )

--- a/docs/development/design.md
+++ b/docs/development/design.md
@@ -2,7 +2,7 @@
 
 ## Scope and Goals
 
-- Provide a package manager for Meson projects, centered on Meson's wrap system.
+- Extend Meson's wrap system with modern package management: resolution, lockfiles, repositories, and publishing.
 - Keep the workflow minimal: publish, search, add, lock, and setup.
 - Support offline installs by caching wraps and archives locally.
 - Allow hosting of internal repositories with a single filesystem layout that is WrapDB-compatible.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,11 @@ hide:
   <a href="https://matrix.to/#/#collider:matrix.org"><img src="https://img.shields.io/badge/Join%20chat-%23collider%3Amatrix.org-000000?logo=matrix" alt="Matrix"></a>
 </p>
 
-<p align="center"><strong>A package and dependency manager for Meson projects, centered on Meson's wrap system.</strong></p>
+<p align="center"><strong>Collider brings modern package management to Meson's native wrap ecosystem.</strong></p>
 
-Collider streamlines how you publish, share, and consume Meson wrap packages.
-It works with WrapDB-compatible repositories so your existing Meson workflows stay
-intact while gaining proper dependency management.
+Rather than replacing Meson's dependency model, Collider extends it:
+automatic dependency resolution, lockfiles, and a streamlined day-to-day
+workflow, fully compatible with wraps and WrapDB.
 
 ## Key Features
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,8 +1,8 @@
 # Glossary
 
 Collider
-:   A package and dependency manager for Meson projects, centered on Meson's
-    wrap system.
+:   A tool that brings modern package management to Meson's native wrap
+    ecosystem: dependency resolution, lockfiles, repositories, and publishing.
 
 Collider Home
 :   User-specific configuration directory. Defaults to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "collider-wraps"
 version = "1.4.0"
-description = "A package and dependency manager for Meson projects."
+description = "Modern package management for Meson's wrap ecosystem."
 readme = "README.md"
 authors = [
     { name = "Maxandre Ogeret", email = "maxandre.ogeret@mogrobotics.com" }

--- a/zensical.toml
+++ b/zensical.toml
@@ -3,7 +3,7 @@
 
 [project]
 site_name = "Collider"
-site_description = "A package and dependency manager for Meson projects."
+site_description = "Modern package management for Meson's wrap ecosystem."
 site_url = "https://collider.ee/"
 site_author = "Maxandre Ogeret"
 repo_url = "https://github.com/MaxandreOgeret/collider"


### PR DESCRIPTION
## Summary

Retires the "package and dependency manager" phrasing: Collider does not fetch or build packages itself, Meson does. New positioning: **Collider brings modern package management to Meson's native wrap ecosystem**, extending Meson's dependency model rather than replacing it. Applied consistently to README, docs landing page, glossary, design goals, PyPI/site descriptions, and `--help` output.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.