### PR TITLE
fix: report user errors once at the terminating boundary

### DIFF
--- a/collider/config.py
+++ b/collider/config.py
@@ -69,6 +69,9 @@ def load(*, offline: bool = False) -> Context:
         try:
             config_file = ConfigFile.from_path(config_path)
         except ColliderUserError as exc:
+            # SystemExit bypasses the entrypoint's ColliderUserError reporting,
+            # so surface the message here before terminating.
+            logger.critical(str(exc))
             logger.critical('Fix or delete the config file to regenerate defaults.')
             raise SystemExit(exc.exit_code) from exc
         logger.debug(f'Loaded config file from "{config_path.as_posix()}".')

--- a/collider/entrypoint.py
+++ b/collider/entrypoint.py
@@ -154,8 +154,10 @@ def main() -> int:
         # so report a clean exit code instead of routing it through error_handler.
         return os.EX_UNAVAILABLE
     except ColliderUserError as e:
-        # Usage and user-environment errors are logged at the raise site; exit cleanly
-        # with the carried code instead of routing them through error_handler.
+        # Report usage and user-environment errors here, at the terminating boundary,
+        # so raise sites stay silent and callers that swallow the error and continue
+        # do not leave a CRITICAL line in the output of a successful command.
+        logger.critical(str(e))
         return e.exit_code
 
 

--- a/collider/file_model/FileModelInterface.py
+++ b/collider/file_model/FileModelInterface.py
@@ -103,13 +103,15 @@ class FileModelInterface(ABC):
             # Malformed, schema-invalid, or undeserializable content (bad JSON, bad enum
             # value, unknown registry key) is a user data problem, not a bug.
             # json.JSONDecodeError and UnicodeDecodeError are ValueError subclasses.
-            logger.critical(msg := f'File "{filepath}" is invalid: {exc}')
+            # Log at debug only: callers that swallow this and continue must not leave
+            # a CRITICAL line; the entrypoint reports the message when it terminates.
+            logger.debug(msg := f'File "{filepath}" is invalid: {exc}')
             raise ColliderUserError(msg, os.EX_DATAERR) from exc
         except FileNotFoundError:
             logger.warning(f'File not found: "{filepath}".')
             raise
         except OSError as exc:
-            logger.critical(msg := f'Cannot read file "{filepath}": {exc}')
+            logger.debug(msg := f'Cannot read file "{filepath}": {exc}')
             raise ColliderUserError(msg, os.EX_IOERR) from exc
 
         return loaded_file

--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -147,11 +147,9 @@ class Wrap(RepositoryInterface):
                     # A 200 body that is not a JSON object (e.g. `null`, a list, or
                     # an HTML error page parsed as a string) is a repository data
                     # problem, not a Collider bug.
-                    logger.critical(
-                        f'WrapDB at "{effective_url.geturl()}" returned non-object releases.json.'
-                    )
                     raise ColliderUserError(
-                        'WrapDB returned malformed releases.json.', os.EX_DATAERR
+                        f'WrapDB at "{effective_url.geturl()}" returned non-object releases.json.',
+                        os.EX_DATAERR,
                     )
                 if cache_file is not None:
                     atomic_write_text(cache_file, json.dumps(releases), encoding='utf-8')
@@ -169,11 +167,11 @@ class Wrap(RepositoryInterface):
         if not isinstance(releases, dict):
             # Defensive: covers a non-object cached releases.json (e.g. a list or
             # `null`) that slipped past the network-fetch validation above.
-            logger.critical(
+            raise ColliderUserError(
                 f'Cached releases for "{effective_url.geturl()}" are not a JSON object'
-                f'{f"; delete {cache_file}" if cache_file is not None else ""}.'
+                f'{f"; delete {cache_file}" if cache_file is not None else ""}.',
+                os.EX_DATAERR,
             )
-            raise ColliderUserError('Cached wrap releases are malformed.', os.EX_DATAERR)
         packages, rejected = _wrap_releases_to_packages(releases)
         if rejected:
             logger.warning(

--- a/collider/subcommand/Setup.py
+++ b/collider/subcommand/Setup.py
@@ -101,9 +101,11 @@ Examples:
             if self.meson_setup_args[0] == '--':
                 self.meson_setup_args = self.meson_setup_args[1:]
             else:
-                logger.critical(msg := 'Expected "--" separator before meson arguments.')
-                logger.critical(f'E.g. "collider setup -- {" ".join(self.meson_setup_args)}"')
-                raise ColliderUserError(msg, os.EX_USAGE)
+                raise ColliderUserError(
+                    'Expected "--" separator before meson arguments.\n'
+                    f'E.g. "collider setup -- {" ".join(self.meson_setup_args)}"',
+                    os.EX_USAGE,
+                )
 
     @override
     def execute(self) -> int:

--- a/collider/subcommand/pkg/Info.py
+++ b/collider/subcommand/pkg/Info.py
@@ -173,11 +173,13 @@ class Info(SubcommandInterface):
         try:
             return wrap_path.read_text(encoding='utf-8')
         except UnicodeDecodeError as exc:
-            logger.critical(msg := f'Cannot read wrap file "{wrap_path}": {exc}')
-            raise ColliderUserError(msg, os.EX_DATAERR) from exc
+            raise ColliderUserError(
+                f'Cannot read wrap file "{wrap_path}": {exc}', os.EX_DATAERR
+            ) from exc
         except OSError as exc:
-            logger.critical(msg := f'Cannot read wrap file "{wrap_path}": {exc}')
-            raise ColliderUserError(msg, os.EX_IOERR) from exc
+            raise ColliderUserError(
+                f'Cannot read wrap file "{wrap_path}": {exc}', os.EX_IOERR
+            ) from exc
 
     def _resolve_installed(self, wrap_text: Optional[str]) -> str:
         if wrap_text is None:

--- a/collider/subcommand/pkg/Prune.py
+++ b/collider/subcommand/pkg/Prune.py
@@ -78,6 +78,14 @@ class Prune(SubcommandInterface):
         return run_prune(self.context, dry_run=self.dry_run)
 
 
+class PruneLockUnreadableError(ColliderUserError):
+    """
+    Raised when pruning is skipped because collider.lock cannot be read or parsed.
+    Distinct from other user errors so ``remove --prune`` can tolerate exactly this
+    skip (issue #46) without swallowing real deletion failures.
+    """
+
+
 def run_prune(context: Context, dry_run: bool = False) -> int:
     """
     Remove orphaned Collider-managed wraps from the project.
@@ -88,6 +96,7 @@ def run_prune(context: Context, dry_run: bool = False) -> int:
     :param context: Application context (config, cache, offline).
     :param dry_run: When True, list orphans without deleting.
     :return: Process exit code.
+    :raises PruneLockUnreadableError: When collider.lock exists but cannot be read.
     """
     if not validate_meson_project_cwd():
         return os.EX_NOINPUT
@@ -108,10 +117,11 @@ def run_prune(context: Context, dry_run: bool = False) -> int:
     try:
         lockfile = Lockfile.from_path(lockfile_path)
     except ColliderUserError as exc:
-        # An unreadable user lockfile is a user-data error: surface the carried
-        # exit code so direct prune invocations fail honestly instead of EX_OK.
+        # An unreadable user lockfile is a user-data error: log the skip summary,
+        # then let the error propagate so direct prune invocations fail honestly
+        # with the cause reported at the entrypoint. remove --prune catches it.
         logger.warning('prune skipped: unreadable lockfile; run "collider lock".')
-        return exc.exit_code
+        raise PruneLockUnreadableError(str(exc), exc.exit_code) from exc
     except Exception:
         # Trailing one-liner so scripts can detect the skip without parsing mid-stream logs.
         logger.warning('prune skipped: unreadable lockfile; run "collider lock".')

--- a/collider/subcommand/pkg/Remove.py
+++ b/collider/subcommand/pkg/Remove.py
@@ -17,7 +17,7 @@ from collider.Context import Context
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import Lockfile
 from collider.log import logger
-from collider.subcommand.pkg.Prune import run_prune
+from collider.subcommand.pkg.Prune import PruneLockUnreadableError, run_prune
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils.compat import override
 from collider.utils.meson import SUBPROJECTS_DIR
@@ -127,9 +127,14 @@ class Remove(SubcommandInterface):
         warn_if_lockfile_needs_refresh(self.package_name)
 
         if self.prune:
-            # Deliberately ignore run_prune's exit code: the remove itself succeeded, and
+            # Tolerate only the unreadable-lock skip: the remove itself succeeded, and
             # issue #46 requires remove --prune to exit EX_OK when pruning is skipped.
-            run_prune(self.context)
+            # The skip cause stays discoverable via --verbose (from_path debug log).
+            # Real deletion failures still propagate with their honest exit code.
+            try:
+                run_prune(self.context)
+            except PruneLockUnreadableError:
+                pass
         elif still_needed is not True:
             self._inform_about_remaining_wraps(
                 colliderfile,

--- a/collider/subcommand/pkg/Search.py
+++ b/collider/subcommand/pkg/Search.py
@@ -99,8 +99,7 @@ class Search(SubcommandInterface):
         try:
             self.name_pattern: re.Pattern = re.compile(args.pattern)
         except re.error as e:
-            logger.critical(msg := f'Invalid regex pattern: {e}')
-            raise ColliderUserError(msg, os.EX_USAGE) from e
+            raise ColliderUserError(f'Invalid regex pattern: {e}', os.EX_USAGE) from e
 
     @override
     def execute(self) -> int:

--- a/collider/utils/packaging/resolver.py
+++ b/collider/utils/packaging/resolver.py
@@ -401,7 +401,8 @@ class ColliderProvider(resolvelib.AbstractProvider):  # pylint: disable=too-many
                 # PermissionError, ENOSPC, and friends are real environment failures:
                 # fail loudly as a user error rather than masking them as an empty
                 # dependency set, since strict callers catch only resolver exceptions.
-                logger.critical(msg := f'Could not prepare source for scan: {e}')
+                # Debug log keeps the cause discoverable when a caller swallows this.
+                logger.debug(msg := f'Could not prepare source for scan: {e}')
                 raise ColliderUserError(msg, os.EX_IOERR) from e
 
             source_archive = tmp / 'packagecache' / package.source_filename

--- a/collider/utils/project_state.py
+++ b/collider/utils/project_state.py
@@ -158,8 +158,10 @@ def remove_installed_artifacts(package_name: str) -> bool:
             removed_any = True
     except OSError as exc:
         # A file the user made undeletable is an environment problem, not a Collider bug.
-        logger.critical(msg := f'Could not remove installed files for "{package_name}": {exc}')
-        raise ColliderUserError(msg, os.EX_IOERR) from exc
+        # The entrypoint reports the message; no log here.
+        raise ColliderUserError(
+            f'Could not remove installed files for "{package_name}": {exc}', os.EX_IOERR
+        ) from exc
 
     return removed_any
 
@@ -186,7 +188,7 @@ def managed_package_names(sourcedir: Path) -> Optional[set[str]]:
     if not lock_path.exists():
         return None
 
-    # A present but unreadable/malformed lock is a hard error; from_path reports it accurately.
+    # A present but unreadable/malformed lock is a hard error, reported at the entrypoint.
     # Tolerate a TOCTOU delete between exists() and from_path(): a vanished lock is equivalent
     # to "no lockfile" rather than a user-facing traceback.
     try:
@@ -227,7 +229,7 @@ def detect_locked_wrap_drift(sourcedir: Path) -> list[str]:
     if not lock_path.exists():
         return []
 
-    # A present but unreadable/malformed lock is a hard error; from_path reports it accurately.
+    # A present but unreadable/malformed lock is a hard error, reported at the entrypoint.
     # Tolerate a TOCTOU delete between exists() and from_path(): a vanished lock is equivalent
     # to "no lockfile" rather than a user-facing traceback.
     try:

--- a/test/subcommand/test_prune.py
+++ b/test/subcommand/test_prune.py
@@ -13,6 +13,7 @@ import pytest
 
 from collider.cache import WrapCache
 from collider.Context import Context
+from collider.errors import ColliderUserError
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import LockedPackage, Lockfile
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
@@ -218,10 +219,12 @@ def test_prune_warns_on_corrupt_lockfile(tmp_path: Path, caplog: pytest.LogCaptu
     cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        assert cmd.execute() == os.EX_DATAERR
+        with pytest.raises(ColliderUserError) as excinfo:
+            cmd.execute()
     finally:
         os.chdir(cwd)
 
+    assert excinfo.value.exit_code == os.EX_DATAERR
     assert (subprojects / 'abseil-cpp.wrap').exists()
     assert caplog.records[-1].message == 'prune skipped: unreadable lockfile; run "collider lock".'
 

--- a/test/subcommand/test_remove.py
+++ b/test/subcommand/test_remove.py
@@ -16,12 +16,14 @@ import resolvelib
 
 from collider.cache import WrapCache
 from collider.Context import Context
+from collider.errors import ColliderUserError
 from collider.file_model.colliderfile import Colliderfile
 from collider.file_model.lockfile import LockedPackage, Lockfile
 from collider.Package import WrapPackage
 from collider.repository.entries import RepoPackageEntry
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
 from collider.subcommand.pkg.Add import Add
+from collider.subcommand.pkg.Prune import PruneLockUnreadableError
 from collider.subcommand.pkg.Remove import Remove
 from collider.utils.packaging.Dependency import Dependency, DependencySource
 from collider.utils.packaging.PackageType import PackageType
@@ -173,6 +175,51 @@ def test_remove_with_prune_and_no_lockfile_ends_with_skip_summary(
         os.chdir(cwd)
 
     assert caplog.records[-1].message == 'prune skipped: no lockfile; run "collider lock".'
+
+
+def test_remove_with_prune_propagates_deletion_failure(tmp_path: Path) -> None:
+    """`remove --prune` tolerates only the lock skip: real prune failures propagate."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, None)],
+    )
+
+    cmd = Remove(argparse.Namespace(package='shared', prune=True), _make_context(tmp_path))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch(
+            'collider.subcommand.pkg.Remove.run_prune',
+            side_effect=ColliderUserError('undeletable orphan', os.EX_IOERR),
+        ):
+            with pytest.raises(ColliderUserError) as excinfo:
+                cmd.execute()
+    finally:
+        os.chdir(cwd)
+
+    assert excinfo.value.exit_code == os.EX_IOERR
+
+
+def test_remove_with_prune_tolerates_lock_skip(tmp_path: Path) -> None:
+    """`remove --prune` exits EX_OK when pruning is skipped over an unreadable lock."""
+    _init_project(
+        tmp_path,
+        dependencies=[Dependency('shared', DependencySource.COLLIDER, None)],
+    )
+
+    cmd = Remove(argparse.Namespace(package='shared', prune=True), _make_context(tmp_path))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with patch(
+            'collider.subcommand.pkg.Remove.run_prune',
+            side_effect=PruneLockUnreadableError('lock unreadable', os.EX_DATAERR),
+        ):
+            assert cmd.execute() == os.EX_OK
+    finally:
+        os.chdir(cwd)
 
 
 def test_remove_missing_package_returns_noinput(tmp_path: Path) -> None:
@@ -654,6 +701,8 @@ def test_remove_with_prune_warns_on_corrupt_lockfile(
     assert (subprojects / 'abseil-cpp.wrap').exists()
     # The trailing summary is the last line so scripts can detect the skip.
     assert caplog.records[-1].message == 'prune skipped: unreadable lockfile; run "collider lock".'
+    # A successful command must not leave CRITICAL lines in its output (issue #79).
+    assert not [r for r in caplog.records if r.levelname == 'CRITICAL']
 
 
 def test_remove_keeps_artifacts_when_dependency_index_is_unavailable(

--- a/test/subcommand/test_upgrade.py
+++ b/test/subcommand/test_upgrade.py
@@ -5,6 +5,7 @@
 
 import argparse
 import hashlib
+import logging
 import os
 import urllib.request
 
@@ -544,6 +545,8 @@ def test_upgrade_ignores_corrupt_lockfile_warning_check(
     tmp_path: Path, monkeypatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Upgrade still succeeds when collider.lock exists but is unreadable."""
+    # The cause is logged at DEBUG; capture it regardless of the singleton logger level.
+    caplog.set_level(logging.DEBUG, logger='collider')
     _init_project(
         tmp_path,
         [Dependency('shared', DependencySource.COLLIDER, None)],
@@ -574,4 +577,7 @@ def test_upgrade_ignores_corrupt_lockfile_warning_check(
         os.chdir(cwd)
 
     assert (tmp_path / 'subprojects' / 'shared.wrap').exists()
+    # The unreadable lock is reported at debug only: a successful command must not
+    # leave CRITICAL lines in its output (issue #79).
     assert 'collider.lock" is invalid' in caplog.text
+    assert not [r for r in caplog.records if r.levelname == 'CRITICAL']


### PR DESCRIPTION
## Summary

`ColliderUserError` raise sites no longer log CRITICAL; the entrypoint reports the carried message once when the error actually terminates the command. Best-effort paths that swallow the error and continue (upgrade/remove/prune lock refresh checks, colliderfile scoping) no longer print CRITICAL lines on successful runs, while every failing path keeps a single, accurate message. Direct `pkg prune` on an unreadable lock now shows the cause without `--verbose`; `remove --prune` tolerates exactly the lock-skip (via a dedicated `PruneLockUnreadableError`) so real deletion failures still propagate honestly. Closes #79

Adversarially reviewed in two passes; both reviewer gates (order-dependent test, over-broad swallow in `remove --prune`) are fixed and pinned by tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.