### PR TITLE
chore: release 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "collider-wraps"
-version = "1.4.0"
+version = "1.5.0"
 description = "Modern package management for Meson's wrap ecosystem."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "collider-wraps"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

Version bump for the 1.5.0 release. Highlights since 1.4.0: honest exit codes for usage and user-environment failures across all subcommands (`ColliderUserError` reported once at the entrypoint), script-detectable prune-skip summaries, tar extraction fixed on pre-PEP 706 interpreters (3.10.0-3.10.11 / 3.11.0-3.11.3), corrupt releases-cache self-healing, mobile version selector on the docs site, and the new positioning copy.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (please describe): release version bump

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.