### PR TITLE
fix: codacy code quality improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Load deploy key
         if: ${{ steps.target.outputs.skip != 'true' }}
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.DOCS_DEPLOY_SSH_KEY }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Create venv
         run: uv venv
       - name: Install tools

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,4 +48,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Install dependencies
         run: uv sync --group dev
       - name: Pytest
         run: uv run pytest --cov=collider --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
         if: matrix.python-version == '3.13' && !cancelled()
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/collider/cache.py
+++ b/collider/cache.py
@@ -264,6 +264,10 @@ class WrapCache:
             shutil.copy2(local_path, cached_path)
             return cached_path
 
+        # Untrusted wrap metadata must never reach a non-http(s) network sink (SSRF).
+        if parsed.scheme not in ('http', 'https'):
+            raise ValueError(f'Unsupported archive URL scheme "{parsed.scheme}" for "{safe_name}".')
+
         if offline:
             # Offline mode must be explicit about missing archives.
             raise FileNotFoundError(f'Archive not found in cache: {safe_name}')

--- a/collider/cache.py
+++ b/collider/cache.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 from collider.log import logger
 from collider.Package import WrapPackage
+from collider.utils import network
 from collider.utils.core import assert_safe_path_segment, is_safe_path_segment
 from collider.utils.fs import atomic_write_text
 from collider.utils.meson.scan import ScannedDependency
@@ -272,16 +273,27 @@ class WrapCache:
             # Offline mode must be explicit about missing archives.
             raise FileNotFoundError(f'Archive not found in cache: {safe_name}')
 
+        # The URL comes from untrusted wrap metadata: refuse hosts in blocked ranges and
+        # keep every redirect hop governed so the fetch cannot pivot into internal services.
+        network.assert_fetchable_url(url)
+
         with tempfile.NamedTemporaryFile('wb+', delete=False) as tmp_file:
             tmp_path = Path(tmp_file.name)
             try:
-                with urllib.request.urlopen(url, timeout=DEFAULT_NETWORK_TIMEOUT) as response:
+                with network.safe_urlopen(
+                    url, timeout=DEFAULT_NETWORK_TIMEOUT, check_redirect_hosts=True
+                ) as response:
                     tmp_file.write(response.read())
             except urllib.error.URLError as exc:
                 tmp_path.unlink(missing_ok=True)
                 raise FileNotFoundError(
                     f'Failed to download archive "{safe_name}" from "{url}": {exc}'
                 ) from exc
+            except ValueError:
+                # A redirect into a blocked host or scheme raises ValueError from the SSRF
+                # guard; clean up the temp file and let the security error propagate.
+                tmp_path.unlink(missing_ok=True)
+                raise
 
         file_hash = compute_file_hash(tmp_path)
         if file_hash != expected_hash:

--- a/collider/cache.py
+++ b/collider/cache.py
@@ -273,6 +273,29 @@ class WrapCache:
             # Offline mode must be explicit about missing archives.
             raise FileNotFoundError(f'Archive not found in cache: {safe_name}')
 
+        tmp_path = self._download_archive(url, safe_name)
+
+        file_hash = compute_file_hash(tmp_path)
+        if file_hash != expected_hash:
+            tmp_path.unlink(missing_ok=True)
+            raise ValueError(
+                f'Archive hash mismatch for "{safe_name}": '
+                f'expected {expected_hash}, got {file_hash}.'
+            )
+
+        cached_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            tmp_path.replace(cached_path)
+        except OSError as exc:
+            if exc.errno != errno.EXDEV:
+                raise
+            # /tmp and cache may live on different filesystems, so fall back to a move.
+            shutil.move(tmp_path, cached_path)
+        return cached_path
+
+    @staticmethod
+    def _download_archive(url: str, safe_name: str) -> Path:
+        """Download an archive to a temp file while enforcing the SSRF guard on every hop."""
         # The URL comes from untrusted wrap metadata: refuse hosts in blocked ranges and
         # keep every redirect hop governed so the fetch cannot pivot into internal services.
         network.assert_fetchable_url(url)
@@ -294,21 +317,4 @@ class WrapCache:
                 # guard; clean up the temp file and let the security error propagate.
                 tmp_path.unlink(missing_ok=True)
                 raise
-
-        file_hash = compute_file_hash(tmp_path)
-        if file_hash != expected_hash:
-            tmp_path.unlink(missing_ok=True)
-            raise ValueError(
-                f'Archive hash mismatch for "{safe_name}": '
-                f'expected {expected_hash}, got {file_hash}.'
-            )
-
-        cached_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            tmp_path.replace(cached_path)
-        except OSError as exc:
-            if exc.errno != errno.EXDEV:
-                raise
-            # /tmp and cache may live on different filesystems, so fall back to a move.
-            shutil.move(tmp_path, cached_path)
-        return cached_path
+        return tmp_path

--- a/collider/file_model/FileModelInterface.py
+++ b/collider/file_model/FileModelInterface.py
@@ -66,8 +66,6 @@ class FileModelInterface(ABC):
 
     def _set_path(self, path: Path) -> None:
         """Reject directory paths to avoid clobbering folders."""
-        assert isinstance(path, Path)
-
         if path.is_dir():
             logger.error(msg := f'File save path must not be a directory: {path}')
             raise TypeError(msg)
@@ -80,8 +78,6 @@ class FileModelInterface(ABC):
         data = json.load(stream)
 
         loaded_file = cls(path=Path(stream.name), **prepare_ctor_kwargs(data, cls))
-        assert isinstance(loaded_file, cls)
-        assert loaded_file.get_path() is not None
 
         if not loaded_file.validate():
             raise TypeError('Failed to validate file before loading.')

--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -34,7 +34,14 @@ def _get_pkg_wrap_url(url: urllib.parse.ParseResult, package: RepoPackageEntry) 
     name = assert_safe_path_segment(package.name)
     version = assert_safe_path_segment(package.version, 'version')
     path = f'{name}_{version}/{name}.wrap'
-    return urllib.parse.urljoin(url.geturl(), path)
+    wrap_url = urllib.parse.urljoin(url.geturl(), path)
+    # A colon in name/version makes urljoin read the path as a scheme (e.g. "file:"),
+    # flipping a network fetch to a local or cross-protocol request. Pin to the repo scheme.
+    if urllib.parse.urlparse(wrap_url).scheme != url.scheme:
+        raise ValueError(
+            f'Unsafe wrap URL scheme derived from package "{package.name}" version "{package.version}".'
+        )
+    return wrap_url
 
 
 def _wrap_releases_to_packages(

--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -8,7 +8,6 @@ import json
 import os
 import time
 import urllib.parse
-import urllib.request
 
 from pathlib import Path
 from typing import Optional
@@ -18,6 +17,7 @@ from collider.log import logger
 from collider.Package import WrapPackage
 from collider.repository.entries import RejectedEntry, RepoPackageEntry, packages_from_releases
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
+from collider.utils import network
 from collider.utils.core import assert_safe_path_segment
 from collider.utils.fs import atomic_write_text
 from collider.utils.meson.infoTypes import WrapDbReleasesEntry
@@ -153,7 +153,9 @@ class Wrap(RepositoryInterface):
             logger.debug('Using cached releases.json (within TTL).')
         if releases is None and not offline:
             try:
-                with urllib.request.urlopen(
+                # The repo host is user-configured (may be LAN or loopback), but redirects
+                # must stay on http(s), hence the governed opener.
+                with network.safe_urlopen(
                     releases_url, timeout=DEFAULT_NETWORK_TIMEOUT
                 ) as response:
                     releases = json.load(response)
@@ -216,7 +218,7 @@ class Wrap(RepositoryInterface):
         entry = self.packages[repo_key]
 
         wrap_url = _get_pkg_wrap_url(self.url, entry)
-        with urllib.request.urlopen(wrap_url, timeout=DEFAULT_NETWORK_TIMEOUT) as response:
+        with network.safe_urlopen(wrap_url, timeout=DEFAULT_NETWORK_TIMEOUT) as response:
             wrap_bytes = response.read()
 
         try:

--- a/collider/repository/implementation/Wrap.py
+++ b/collider/repository/implementation/Wrap.py
@@ -30,17 +30,24 @@ _RELEASES_TTL_SECONDS = 300
 
 
 def _get_pkg_wrap_url(url: urllib.parse.ParseResult, package: RepoPackageEntry) -> str:
+    """
+    Build the wrap download URL for a package from untrusted repository metadata.
+    :param url: Base repository URL whose scheme and host the result must keep.
+    :param package: Package entry whose name and version shape the request path.
+    :raises ValueError: When the name or version is an unsafe path segment, or would
+        divert the request to another scheme or host.
+    """
     # Name and version come from untrusted releases.json and shape the request path.
     name = assert_safe_path_segment(package.name)
     version = assert_safe_path_segment(package.version, 'version')
     path = f'{name}_{version}/{name}.wrap'
     wrap_url = urllib.parse.urljoin(url.geturl(), path)
-    # A colon in name/version makes urljoin read the path as a scheme (e.g. "file:"),
-    # flipping a network fetch to a local or cross-protocol request. Pin to the repo scheme.
-    if urllib.parse.urlparse(wrap_url).scheme != url.scheme:
-        raise ValueError(
-            f'Unsafe wrap URL scheme derived from package "{package.name}" version "{package.version}".'
-        )
+    # A colon in the package name makes urljoin read the path as a scheme (e.g. "file:"),
+    # and a leading slash lets it override the host; either would divert the fetch off the
+    # repository. Keep the guard self-contained by pinning both scheme and host.
+    parsed = urllib.parse.urlparse(wrap_url)
+    if parsed.scheme != url.scheme or parsed.netloc != url.netloc:
+        raise ValueError(f'Package "{package.name}" produced an unsafe wrap URL: {wrap_url}.')
     return wrap_url
 
 

--- a/collider/subcommand/pkg/Add.py
+++ b/collider/subcommand/pkg/Add.py
@@ -344,10 +344,14 @@ class Add(SubcommandInterface):  # pylint: disable=too-many-instance-attributes
                     newest_repo = repos[repo_name]
                     newest_key = repo_key
 
-        assert newest_entry is not None
-        assert newest_repo_name is not None
-        assert newest_repo is not None
-        assert newest_key is not None
+        # Every match may have been skipped for an invalid version.
+        if (
+            newest_entry is None
+            or newest_repo_name is None
+            or newest_repo is None
+            or newest_key is None
+        ):
+            return None
 
         return newest_entry, newest_repo_name, newest_repo, newest_key
 

--- a/collider/subcommand/pkg/__init__.py
+++ b/collider/subcommand/pkg/__init__.py
@@ -9,7 +9,6 @@ import argparse
 import os
 import sys
 
-from collider.Context import Context
 from collider.log import logger
 from collider.subcommand.SubcommandInterface import SubcommandInterface
 from collider.utils import core

--- a/collider/utils/command.py
+++ b/collider/utils/command.py
@@ -35,10 +35,6 @@ def run(
     :return: Captured output string, or None if capture is NONE.
     """
     logger.debug(f'Running command: {args}')
-    assert isinstance(args, list), f'Arg list "{args}" is not a list.'
-    for arg in args:
-        assert isinstance(arg, str), f'Argument "{arg}" is not a string.'
-
     resolved_cwd = Path.cwd() if cwd is None else cwd
 
     process = subprocess.run(

--- a/collider/utils/network.py
+++ b/collider/utils/network.py
@@ -3,6 +3,8 @@
 
 """Shared network defaults and safe HTTP access for HTTP(S)."""
 
+import ipaddress
+import socket
 import urllib.parse
 import urllib.request
 
@@ -23,13 +25,94 @@ def _origin(url: str) -> tuple[str, str, int]:
     return scheme, host, port
 
 
+def _resolve_host_addresses(host: str) -> list[str]:
+    """
+    Resolve a host to its IP addresses. Module-level so tests can stub resolution.
+    :param host: Hostname or IP literal.
+    :return: All resolved address strings.
+    """
+    infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    return [str(info[4][0]) for info in infos]
+
+
+def _is_blocked_address(address: str) -> bool:
+    """
+    Whether an address is in a range that must never be fetched (SSRF guard).
+    Private LAN ranges stay allowed because self-hosted repositories are supported.
+    :param address: IP address string.
+    """
+    ip = ipaddress.ip_address(address)
+    # Judge an IPv4-mapped IPv6 address by its embedded IPv4 address; the mapped form does
+    # not reliably report loopback/link-local on all supported Python versions.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return (
+        ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+    )
+
+
+def _host_is_blocked(host: str) -> bool:
+    """
+    Whether any resolved address of the host is in a blocked range.
+    :param host: Hostname or IP literal.
+    :raises ValueError: When the host cannot be resolved (fail closed).
+    """
+    try:
+        addresses = _resolve_host_addresses(host)
+    except OSError as exc:
+        raise ValueError(f'Cannot resolve host "{host}": {exc}') from exc
+    return any(_is_blocked_address(address) for address in addresses)
+
+
+def assert_fetchable_url(url: str) -> None:
+    """
+    Reject a URL that untrusted input must never make us fetch (SSRF guard).
+    Only http(s) URLs are allowed, and the host must not resolve to a loopback, link-local,
+    reserved, multicast or unspecified address. Private LAN ranges stay allowed.
+    This validates the resolved host, but the socket layer resolves again on connect, so a
+    low-TTL rebinding record remains a residual gap; closing it requires pinning the checked
+    address into the connection.
+    :param url: URL to validate.
+    :raises ValueError: When the scheme is not http(s) or the host is blocked.
+    """
+    parts = urllib.parse.urlsplit(url)
+    scheme = (parts.scheme or '').lower()
+    if scheme not in ('http', 'https'):
+        raise ValueError(f'Unsupported URL scheme "{scheme}" in "{url}".')
+    host = parts.hostname
+    if not host:
+        raise ValueError(f'URL "{url}" has no host.')
+    if _host_is_blocked(host):
+        raise ValueError(f'Refusing to fetch "{url}": the host resolves to a blocked address.')
+
+
 class _AuthStrippingRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Drop the Authorization header when a redirect crosses to a different origin."""
+    """
+    Drop the Authorization header when a redirect crosses to a different origin, and pin
+    redirect targets to http(s). With check_redirect_hosts, every redirect hop is also
+    re-validated against the blocked address ranges.
+    """
+
+    def __init__(self, *, check_redirect_hosts: bool = False):
+        """
+        :param check_redirect_hosts: Reject redirects whose host resolves to a blocked
+            address. Enable when the initial URL comes from untrusted input.
+        """
+        self.check_redirect_hosts = check_redirect_hosts
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
         if new_req is None:
             return None
+        new_scheme, new_host, _ = _origin(newurl)
+        # CPython's default handler follows ftp:// and file:// Location targets, which
+        # would bypass any scheme allowlist applied to the initial URL.
+        if new_scheme not in ('http', 'https'):
+            raise ValueError(f'Refusing redirect to non-http(s) URL "{newurl}".')
+        # Re-check every hop, including same-host targets: with attacker-controlled DNS a
+        # redirect re-resolves the name and can rebind it into a blocked range (SSRF).
+        if self.check_redirect_hosts and (not new_host or _host_is_blocked(new_host)):
+            raise ValueError(f'Refusing redirect to blocked host in "{newurl}".')
         if _origin(req.full_url) == _origin(newurl):
             return new_req
         # A cross-origin redirect must not carry the bearer token to a new host. urllib keeps
@@ -38,14 +121,30 @@ class _AuthStrippingRedirectHandler(urllib.request.HTTPRedirectHandler):
         return new_req
 
 
-def build_safe_opener() -> urllib.request.OpenerDirector:
-    """Build an opener that strips credentials on cross-origin redirects."""
-    return urllib.request.build_opener(_AuthStrippingRedirectHandler)
+def build_safe_opener(*, check_redirect_hosts: bool = False) -> urllib.request.OpenerDirector:
+    """
+    Build an opener that strips credentials on cross-origin redirects and pins redirect
+    targets to http(s).
+    :param check_redirect_hosts: Also reject redirect hosts resolving to blocked addresses.
+    """
+    return urllib.request.build_opener(
+        _AuthStrippingRedirectHandler(check_redirect_hosts=check_redirect_hosts)
+    )
 
 
-def safe_urlopen(request, *, timeout: float = DEFAULT_NETWORK_TIMEOUT):
-    """Open a request through the cross-origin credential-stripping opener."""
-    return build_safe_opener().open(request, timeout=timeout)
+def safe_urlopen(
+    request, *, timeout: float = DEFAULT_NETWORK_TIMEOUT, check_redirect_hosts: bool = False
+):
+    """
+    Open a request through the cross-origin credential-stripping opener.
+    :param request: URL string or Request to open.
+    :param timeout: Socket timeout in seconds.
+    :param check_redirect_hosts: Reject redirect hosts resolving to blocked addresses.
+        Enable when the URL comes from untrusted input.
+    """
+    return build_safe_opener(check_redirect_hosts=check_redirect_hosts).open(
+        request, timeout=timeout
+    )
 
 
 def may_send_push_token(url: urllib.parse.ParseResult, *, insecure: bool) -> bool:

--- a/test/cache/test_cache.py
+++ b/test/cache/test_cache.py
@@ -4,7 +4,7 @@
 import hashlib
 import io
 import shutil
-import urllib.request
+import tempfile
 
 from pathlib import Path
 
@@ -12,6 +12,7 @@ import pytest
 
 from collider.cache import WrapCache
 from collider.Package import WrapPackage
+from collider.utils import network
 
 
 class _DummyResponse:
@@ -112,10 +113,60 @@ def test_wrap_cache_ensure_archive_rejects_non_http_scheme(tmp_path: Path, monke
     def _fail_urlopen(*_args, **_kwargs):
         raise AssertionError('urlopen must not be reached for a non-http(s) scheme.')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fail_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fail_urlopen)
 
     with pytest.raises(ValueError, match='Unsupported archive URL scheme'):
         cache.prepare_packagecache(package, tmp_path / 'subprojects', offline=False)
+
+
+def test_wrap_cache_ensure_archive_rejects_blocked_host(tmp_path: Path, monkeypatch):
+    """An archive host resolving to a blocked address is rejected before any fetch (SSRF guard)."""
+    cache = WrapCache(tmp_path / 'cache')
+    source_hash = hashlib.sha256(b'x').hexdigest()
+    package = WrapPackage.from_wrap_text(
+        'foo',
+        '1.0.0',
+        '[wrap-file]\n'
+        'source_url=https://metadata.internal/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        f'source_hash={source_hash}\n',
+    )
+
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: ['169.254.169.254'])
+
+    def _fail_fetch(*_args, **_kwargs):
+        raise AssertionError('The network must not be reached for a blocked host.')
+
+    monkeypatch.setattr(network, 'safe_urlopen', _fail_fetch)
+
+    with pytest.raises(ValueError, match='blocked'):
+        cache.prepare_packagecache(package, tmp_path / 'subprojects', offline=False)
+
+
+def test_wrap_cache_ensure_archive_cleans_temp_on_blocked_redirect(tmp_path: Path, monkeypatch):
+    """A redirect blocked mid-download surfaces the security error and leaves no temp file."""
+    cache = WrapCache(tmp_path / 'cache')
+    source_hash = hashlib.sha256(b'x').hexdigest()
+    package = WrapPackage.from_wrap_text(
+        'foo',
+        '1.0.0',
+        '[wrap-file]\n'
+        'source_url=https://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        f'source_hash={source_hash}\n',
+    )
+
+    def _redirect_blocked(*_args, **_kwargs):
+        raise ValueError('Refusing redirect to blocked host in "https://169.254.169.254/x".')
+
+    monkeypatch.setattr(network, 'safe_urlopen', _redirect_blocked)
+    before = set(Path(tempfile.gettempdir()).glob('tmp*'))
+
+    with pytest.raises(ValueError, match='Refusing redirect'):
+        cache.prepare_packagecache(package, tmp_path / 'subprojects', offline=False)
+
+    leaked = set(Path(tempfile.gettempdir()).glob('tmp*')) - before
+    assert leaked == set()
 
 
 def test_wrap_cache_has_package(tmp_path: Path):
@@ -156,7 +207,7 @@ def test_wrap_cache_prepare_packagecache_downloads(tmp_path: Path, monkeypatch):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(content)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     cache.prepare_packagecache(package, subprojects, offline=False)
 
@@ -177,7 +228,7 @@ def test_wrap_cache_prepare_packagecache_handles_cross_device(tmp_path: Path, mo
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(content)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     moved = {'value': False}
     original_move = shutil.move
@@ -223,7 +274,7 @@ def test_wrap_cache_download_hash_mismatch(tmp_path: Path, monkeypatch):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(content)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     with pytest.raises(ValueError, match='Archive hash mismatch'):
         cache.prepare_packagecache(package, subprojects, offline=False)
@@ -270,7 +321,7 @@ def test_wrap_cache_warns_http_url(tmp_path: Path, monkeypatch, caplog):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(b'payload')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     caplog.set_level('WARNING')
     with pytest.raises(ValueError, match='Archive hash mismatch'):

--- a/test/cache/test_cache.py
+++ b/test/cache/test_cache.py
@@ -114,7 +114,7 @@ def test_wrap_cache_ensure_archive_rejects_non_http_scheme(tmp_path: Path, monke
 
     monkeypatch.setattr(urllib.request, 'urlopen', _fail_urlopen)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Unsupported archive URL scheme'):
         cache.prepare_packagecache(package, tmp_path / 'subprojects', offline=False)
 
 

--- a/test/cache/test_cache.py
+++ b/test/cache/test_cache.py
@@ -96,6 +96,28 @@ def test_wrap_cache_ensure_archive_rejects_unsafe_hash(tmp_path: Path):
     assert not (tmp_path.parent / 'evil-foo.tar.xz').exists()
 
 
+def test_wrap_cache_ensure_archive_rejects_non_http_scheme(tmp_path: Path, monkeypatch):
+    """A non-http(s) source_url is rejected before any network fetch happens (SSRF guard)."""
+    cache = WrapCache(tmp_path / 'cache')
+    source_hash = hashlib.sha256(b'x').hexdigest()
+    package = WrapPackage.from_wrap_text(
+        'foo',
+        '1.0.0',
+        '[wrap-file]\n'
+        'source_url=ftp://example.com/foo.tar.xz\n'
+        'source_filename=foo.tar.xz\n'
+        f'source_hash={source_hash}\n',
+    )
+
+    def _fail_urlopen(*_args, **_kwargs):
+        raise AssertionError('urlopen must not be reached for a non-http(s) scheme.')
+
+    monkeypatch.setattr(urllib.request, 'urlopen', _fail_urlopen)
+
+    with pytest.raises(ValueError):
+        cache.prepare_packagecache(package, tmp_path / 'subprojects', offline=False)
+
+
 def test_wrap_cache_has_package(tmp_path: Path):
     cache = WrapCache(tmp_path / 'cache')
 

--- a/test/common/__init__.py
+++ b/test/common/__init__.py
@@ -1,4 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 MOG Robotics OÜ
-
-from .common import *

--- a/test/common/fixture.py
+++ b/test/common/fixture.py
@@ -39,6 +39,17 @@ def mock_home(tmp_path: Path):
     os.chdir(original_cwd)
 
 
+@pytest.fixture(autouse=True)
+def stub_dns(monkeypatch):
+    """
+    Resolve every host to a public address so unit tests never perform real DNS.
+    Tests that exercise blocked-address handling override this stub locally.
+    """
+    monkeypatch.setattr(
+        'collider.utils.network._resolve_host_addresses', lambda _host: ['93.184.216.34']
+    )
+
+
 @pytest.fixture(scope='function')
 def temp_empty_meson_project(pytestconfig: pytest.Config):
     empty_project = pytestconfig.rootpath / 'test' / 'assets' / 'pkg' / 'none'

--- a/test/contract/test_pkg_add_exit_codes.py
+++ b/test/contract/test_pkg_add_exit_codes.py
@@ -122,6 +122,28 @@ def test_pkg_add_ex_unavailable_no_matching_package(tmp_path: Path) -> None:
     assert not (tmp_path / Colliderfile.get_filename()).exists()
 
 
+def test_pkg_add_ex_unavailable_all_versions_invalid(tmp_path: Path) -> None:
+    """pkg add returns EX_UNAVAILABLE when every matching package has an unparsable version."""
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    repo.requires_network.return_value = False
+    context = _make_context(tmp_path, {'repo1': repo})
+    cmd = Add(_add_args('broken'), context)
+
+    broken_key = make_repo_key('broken', 'not-a-version', PackageType.WRAP)
+    broken_entry = RepoPackageEntry('broken', 'not-a-version', PackageType.WRAP)
+
+    os.chdir(tmp_path)
+    with patch(
+        'collider.subcommand.pkg.Add.search_packages',
+        return_value={'repo1': {broken_key: broken_entry}},
+    ):
+        assert cmd.execute() == os.EX_UNAVAILABLE
+    assert not (tmp_path / Colliderfile.get_filename()).exists()
+
+
 def test_pkg_add_lists_available_versions_when_pin_matches_nothing(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/test/contract/test_pkg_add_exit_codes.py
+++ b/test/contract/test_pkg_add_exit_codes.py
@@ -62,6 +62,31 @@ def _add_args(package: str, *, offline: bool = False, version: object = None) ->
     )
 
 
+def _make_add_cmd(
+    tmp_path: Path,
+    package: str,
+    *,
+    requires_network: bool = False,
+    offline: bool = False,
+    version: object = None,
+) -> Add:
+    """
+    Create a meson project in tmp_path and build an Add command against one mocked repository.
+    :param tmp_path: Temporary project directory.
+    :param package: Package name to add.
+    :param requires_network: Whether the mocked repository requires network access.
+    :param offline: Whether to run in offline mode.
+    :param version: Optional parsed version constraint (SpecifierSet).
+    :return: Add command ready to execute.
+    """
+    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
+    repo = MagicMock(spec=RepositoryInterface)
+    repo.packages = {}
+    repo.requires_network.return_value = requires_network
+    context = _make_context(tmp_path, {'repo1': repo})
+    return Add(_add_args(package, offline=offline, version=version), context)
+
+
 def test_pkg_add_ex_noinput_no_meson_build(tmp_path: Path) -> None:
     """pkg add returns EX_NOINPUT when no meson.build exists in the working directory."""
     os.chdir(tmp_path)
@@ -108,13 +133,7 @@ def test_pkg_add_ex_ok_existing_transitive_wrap_promoted(tmp_path: Path) -> None
 
 def test_pkg_add_ex_unavailable_no_matching_package(tmp_path: Path) -> None:
     """pkg add returns EX_UNAVAILABLE when no repository yields a matching package."""
-    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
-
-    repo = MagicMock(spec=RepositoryInterface)
-    repo.packages = {}
-    repo.requires_network.return_value = False
-    context = _make_context(tmp_path, {'repo1': repo})
-    cmd = Add(_add_args('ghost'), context)
+    cmd = _make_add_cmd(tmp_path, 'ghost')
 
     os.chdir(tmp_path)
     with patch('collider.subcommand.pkg.Add.search_packages', return_value={}):
@@ -124,13 +143,7 @@ def test_pkg_add_ex_unavailable_no_matching_package(tmp_path: Path) -> None:
 
 def test_pkg_add_ex_unavailable_all_versions_invalid(tmp_path: Path) -> None:
     """pkg add returns EX_UNAVAILABLE when every matching package has an unparsable version."""
-    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
-
-    repo = MagicMock(spec=RepositoryInterface)
-    repo.packages = {}
-    repo.requires_network.return_value = False
-    context = _make_context(tmp_path, {'repo1': repo})
-    cmd = Add(_add_args('broken'), context)
+    cmd = _make_add_cmd(tmp_path, 'broken')
 
     broken_key = make_repo_key('broken', 'not-a-version', PackageType.WRAP)
     broken_entry = RepoPackageEntry('broken', 'not-a-version', PackageType.WRAP)
@@ -148,13 +161,7 @@ def test_pkg_add_lists_available_versions_when_pin_matches_nothing(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A version pin that matches nothing surfaces the versions the repositories actually offer."""
-    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
-
-    repo = MagicMock(spec=RepositoryInterface)
-    repo.packages = {}
-    repo.requires_network.return_value = False
-    context = _make_context(tmp_path, {'repo1': repo})
-    cmd = Add(_add_args('zlib', version=SpecifierSet('==1.2.13')), context)
+    cmd = _make_add_cmd(tmp_path, 'zlib', version=SpecifierSet('==1.2.13'))
 
     zlib_key = make_repo_key('zlib', '1.2.13-1', PackageType.WRAP)
     zlib_entry = RepoPackageEntry('zlib', '1.2.13-1', PackageType.WRAP)
@@ -176,13 +183,7 @@ def test_pkg_add_lists_available_versions_when_pin_matches_nothing(
 
 def test_pkg_add_ex_ioerr_offline_missing_cache(tmp_path: Path) -> None:
     """pkg add returns EX_IOERR when an offline install finds the package uncached."""
-    (tmp_path / 'meson.build').write_text('project("dummy", "c")\n', encoding='utf-8')
-
-    repo = MagicMock(spec=RepositoryInterface)
-    repo.packages = {}
-    repo.requires_network.return_value = True
-    context = _make_context(tmp_path, {'repo1': repo})
-    cmd = Add(_add_args('demo', offline=True), context)
+    cmd = _make_add_cmd(tmp_path, 'demo', requires_network=True, offline=True)
 
     demo_key = make_repo_key('demo', '1.0.0', PackageType.WRAP)
     demo_entry = RepoPackageEntry('demo', '1.0.0', PackageType.WRAP)

--- a/test/repository/implementation/test_mesonwrapdb.py
+++ b/test/repository/implementation/test_mesonwrapdb.py
@@ -7,7 +7,6 @@ import os
 import time
 import urllib.error
 import urllib.parse
-import urllib.request
 
 import pytest
 
@@ -55,7 +54,7 @@ def test_wrap_from_url_fetches_releases(monkeypatch):
         called['url'] = url
         return _DummyResponse(payload)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/')
     assert isinstance(repo, Wrap)
@@ -78,7 +77,7 @@ def test_wrap_from_url_warns_missing_v2(monkeypatch, caplog):
         called['url'] = url
         return _DummyResponse(payload)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     caplog.set_level('WARNING')
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com')
@@ -95,7 +94,7 @@ def test_wrap_from_url_warns_http(monkeypatch, caplog):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(payload)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     caplog.set_level('WARNING')
     repo = Wrap.from_url('http://wrapdb.mesonbuild.com/v2/')
@@ -226,7 +225,7 @@ def test_wrap_get_package_parses_wrap(monkeypatch):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(wrap_text)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
     repo_key = make_repo_key('foo', '1.0.0', PackageType.WRAP)
@@ -298,7 +297,7 @@ def test_wrap_from_url_uses_ttl_cache_when_fresh(tmp_path, monkeypatch):
         http_called = True
         return _DummyResponse(json.dumps({'bar': {'versions': ['2.0.0']}}))
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
     assert not http_called
@@ -315,7 +314,7 @@ def test_wrap_from_url_corrupt_ttl_cache_refetches(tmp_path, monkeypatch):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(json.dumps({'fresh': {'versions': ['3.0.0']}}))
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
     assert make_repo_key('fresh', '3.0.0', PackageType.WRAP) in repo.packages
@@ -333,7 +332,7 @@ def test_wrap_from_url_network_failure_falls_back_to_stale_cache(tmp_path, monke
     def _fail_urlopen(url, **_kwargs):
         raise urllib.error.URLError('network down')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fail_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fail_urlopen)
 
     with caplog.at_level('WARNING'):
         repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
@@ -348,7 +347,7 @@ def test_wrap_from_url_null_body_raises_user_error(tmp_path, monkeypatch):
     def _null_urlopen(url, **_kwargs):
         return _DummyResponse('null')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _null_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _null_urlopen)
 
     with pytest.raises(ColliderUserError) as excinfo:
         Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
@@ -379,7 +378,7 @@ def test_wrap_from_url_network_failure_with_corrupt_cache_raises(tmp_path, monke
     def _fail_urlopen(url, **_kwargs):
         raise urllib.error.URLError('network down')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fail_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fail_urlopen)
 
     with pytest.raises(urllib.error.URLError):
         Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
@@ -412,7 +411,7 @@ def test_wrap_from_url_fetches_when_ttl_expired(tmp_path, monkeypatch):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(json.dumps({'fresh': {'versions': ['3.0.0']}}))
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
     assert make_repo_key('fresh', '3.0.0', PackageType.WRAP) in repo.packages
@@ -426,7 +425,7 @@ def test_wrap_from_url_fetches_when_no_cache(tmp_path, monkeypatch):
     def _fake_urlopen(url, **_kwargs):
         return _DummyResponse(json.dumps({'new': {'versions': ['1.0.0']}}))
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path)
     assert make_repo_key('new', '1.0.0', PackageType.WRAP) in repo.packages
@@ -449,7 +448,7 @@ def test_wrap_from_url_ttl_not_checked_in_offline_mode(tmp_path, monkeypatch):
         http_called = True
         return _DummyResponse(json.dumps({}))
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _fake_urlopen)
 
     repo = Wrap.from_url('https://wrapdb.mesonbuild.com/v2/', cache_path=cache_path, offline=True)
     assert not http_called

--- a/test/repository/implementation/test_mesonwrapdb.py
+++ b/test/repository/implementation/test_mesonwrapdb.py
@@ -165,7 +165,7 @@ def test_wrap_url_builder_rejects_scheme_injection():
     """A colon in the name must not flip the wrap URL to a local or cross-protocol scheme."""
     url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
     entry = RepoPackageEntry('file:evil', '1.0', PackageType.WRAP)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='unsafe wrap URL'):
         _get_pkg_wrap_url(url, entry)
 
 

--- a/test/repository/implementation/test_mesonwrapdb.py
+++ b/test/repository/implementation/test_mesonwrapdb.py
@@ -161,6 +161,24 @@ def test_wrap_url_builder_rejects_unsafe_version():
         _get_pkg_wrap_url(url, entry)
 
 
+def test_wrap_url_builder_rejects_scheme_injection():
+    """A colon in the name must not flip the wrap URL to a local or cross-protocol scheme."""
+    url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
+    entry = RepoPackageEntry('file:evil', '1.0', PackageType.WRAP)
+    with pytest.raises(ValueError):
+        _get_pkg_wrap_url(url, entry)
+
+
+def test_wrap_url_builder_allows_colon_in_version():
+    """A colon in the version is a valid segment and must stay pinned to the repo scheme."""
+    url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
+    entry = RepoPackageEntry('foo', 'ftp:1.0', PackageType.WRAP)
+
+    wrap_url = _get_pkg_wrap_url(url, entry)
+    assert wrap_url == 'https://wrapdb.mesonbuild.com/v2/foo_ftp:1.0/foo.wrap'
+    assert urllib.parse.urlparse(wrap_url).scheme == 'https'
+
+
 def test_wrap_url_builders():
     url = urllib.parse.urlparse('https://wrapdb.mesonbuild.com/v2/')
     entry = RepoPackageEntry('foo', '1.2.3', PackageType.WRAP)

--- a/test/subcommand/test_install.py
+++ b/test/subcommand/test_install.py
@@ -6,7 +6,6 @@
 import argparse
 import hashlib
 import os
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -85,7 +84,9 @@ def test_install_wrap_success(tmp_path: Path, monkeypatch) -> None:
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -214,7 +215,9 @@ def test_install_preserves_declared_version(tmp_path: Path, monkeypatch) -> None
     entry = RepoPackageEntry('shared', '2.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -251,7 +254,9 @@ def test_install_honors_declared_version_constraint(tmp_path: Path, monkeypatch)
     entry = RepoPackageEntry('shared', '1.5.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -290,7 +295,9 @@ def test_install_with_version_flag_persists_constraint(tmp_path: Path, monkeypat
     entry = RepoPackageEntry('shared', '1.5.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', version=SpecifierSet('>=1.0,<2.0'), offline=False)
     cmd = Add(args, context)
@@ -350,7 +357,9 @@ def test_install_fails_on_existing_different_wrap(
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -388,7 +397,9 @@ def test_install_does_not_create_lockfile(tmp_path: Path, monkeypatch) -> None:
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -435,7 +446,9 @@ def test_install_does_not_update_existing_lockfile(
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -488,7 +501,9 @@ def test_install_does_not_warn_when_lockfile_already_matches(
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)
@@ -571,7 +586,9 @@ def test_install_adds_dependency_without_version(tmp_path: Path, monkeypatch) ->
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(package='shared', offline=False)
     cmd = Add(args, context)

--- a/test/subcommand/test_install_command.py
+++ b/test/subcommand/test_install_command.py
@@ -6,7 +6,6 @@
 import argparse
 import hashlib
 import os
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -100,7 +99,9 @@ def test_install_from_lockfile(tmp_path: Path, monkeypatch) -> None:
     repo.search.return_value = {repo_key: RepoPackageEntry('foo', '1.0.0', PackageType.WRAP)}
 
     context = _make_context(tmp_path, repo)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False, frozen=False)
     cmd = Install(args, context)
@@ -171,7 +172,9 @@ def test_install_fallback_to_colliderfile(tmp_path: Path, monkeypatch) -> None:
     all_matches = {'repo1': {repo_key: entry}}
 
     context = _make_context(tmp_path, repo)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False, frozen=False)
     cmd = Install(args, context)
@@ -206,7 +209,9 @@ def test_install_honors_declared_version_constraint(tmp_path: Path, monkeypatch)
     all_matches = {'repo1': {repo_key: entry}}
 
     context = _make_context(tmp_path, repo)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False, frozen=False)
     cmd = Install(args, context)
@@ -343,7 +348,9 @@ def test_install_warns_when_locked_version_violates_declared_constraint(
     repo.requires_network.return_value = False
     repo.origin_url = ORIGIN
     context = _make_context(tmp_path, repo)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False, frozen=False)
     cmd = Install(args, context)
@@ -583,7 +590,9 @@ def test_install_fetches_from_origin_repo(tmp_path: Path, monkeypatch) -> None:
     repo.requires_network.return_value = False
     repo.origin_url = ORIGIN
     context = _make_context(tmp_path, repo, repo_name='repo1')
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False, frozen=False)
     cmd = Install(args, context)
@@ -675,7 +684,9 @@ def test_install_cross_root_conflict_detected(
     config.offline = False
     context = Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     def mock_get_deps(self_prov, candidate):
         if candidate.name == 'libfoo':
@@ -777,7 +788,9 @@ def test_install_origin_url_normalization(tmp_path: Path, monkeypatch) -> None:
     repo.requires_network.return_value = False
     repo.origin_url = 'https://wrapdb.example.com/v2'
     context = _make_context(tmp_path, repo)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False, frozen=False)
     cmd = Install(args, context)

--- a/test/subcommand/test_install_command.py
+++ b/test/subcommand/test_install_command.py
@@ -649,7 +649,7 @@ def test_install_cross_root_conflict_detected(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Install detects incompatible transitive deps across roots and fails."""
-    from collider.utils.packaging.resolver import Candidate, Requirement
+    from collider.utils.packaging.resolver import Requirement
 
     _init_project(
         tmp_path,

--- a/test/subcommand/test_lock.py
+++ b/test/subcommand/test_lock.py
@@ -8,7 +8,6 @@ import hashlib
 import logging
 import os
 import urllib.error
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -95,7 +94,9 @@ def test_lock_creates_lockfile(tmp_path: Path, monkeypatch) -> None:
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -180,7 +181,9 @@ def test_lock_rewrites_existing_lockfile(tmp_path: Path, monkeypatch) -> None:
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -219,7 +222,9 @@ def test_lock_honors_declared_version_constraint(tmp_path: Path, monkeypatch) ->
     entry = RepoPackageEntry('shared', '1.5.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -367,7 +372,9 @@ def test_lock_cross_root_conflict_detected(
     config.offline = False
     context = Context(config=config, cache=WrapCache(tmp_path / 'cache'), offline=False)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     def mock_get_deps(self_prov, candidate):
         if candidate.name == 'libfoo':
@@ -422,7 +429,9 @@ def test_lock_verifies_source_archive(tmp_path: Path, monkeypatch) -> None:
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -467,7 +476,7 @@ def test_lock_verifies_cached_archive(tmp_path: Path, monkeypatch) -> None:
             raise AssertionError('Should not download pre-cached archive')
         return _DummyResponse(content)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', urlopen_should_not_download)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', urlopen_should_not_download)
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -507,7 +516,9 @@ def test_lock_fails_on_source_archive_hash_mismatch(tmp_path: Path, monkeypatch,
     all_matches = {'repo1': {repo_key: entry}}
 
     tampered = b'tampered content'
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(tampered))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(tampered)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -570,7 +581,7 @@ def test_lock_fails_on_patch_archive_hash_mismatch(tmp_path: Path, monkeypatch, 
             return _DummyResponse(tampered_patch)
         return _DummyResponse(source_content)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', mock_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', mock_urlopen)
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -661,7 +672,7 @@ def test_lock_fails_on_corrupt_cached_archive(tmp_path: Path, monkeypatch, caplo
 
     # Re-download after corrupt cache eviction also returns bad data.
     monkeypatch.setattr(
-        urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(b'still wrong')
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(b'still wrong')
     )
 
     args = argparse.Namespace(offline=False)
@@ -710,7 +721,9 @@ def test_lock_corrupt_cache_redownloads_and_succeeds(tmp_path: Path, monkeypatch
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -761,7 +774,7 @@ def test_lock_corrupt_cache_network_unavailable_fails(tmp_path: Path, monkeypatc
     def mock_urlopen(url, **_kwargs):
         raise urllib.error.URLError('simulated network failure')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', mock_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', mock_urlopen)
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -806,7 +819,7 @@ def test_lock_archive_unreachable_not_cached_fails(tmp_path: Path, monkeypatch, 
     def mock_urlopen(url, **_kwargs):
         raise urllib.error.URLError('simulated unreachable')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', mock_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', mock_urlopen)
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)
@@ -886,7 +899,7 @@ def test_lock_atomicity_second_package_fails(tmp_path: Path, monkeypatch, caplog
             return _DummyResponse(content_a)
         return _DummyResponse(b'tampered')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', mock_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', mock_urlopen)
 
     config = MagicMock()
     config.repositories = {'repo1': repo}
@@ -962,7 +975,7 @@ def test_lock_origin_per_package_matches_source_repo(tmp_path: Path, monkeypatch
             return _DummyResponse(content_a)
         return _DummyResponse(content_b)
 
-    monkeypatch.setattr(urllib.request, 'urlopen', mock_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', mock_urlopen)
 
     config = MagicMock()
     config.repositories = {'repo_a': repo_a, 'repo_b': repo_b}
@@ -1000,7 +1013,9 @@ def test_lock_package_migration_changes_origin(tmp_path: Path, monkeypatch) -> N
     content_hash = hashlib.sha256(content).hexdigest()
     package = WrapPackage.from_wrap_text('shared', '1.0.0', _wrap_text(content_hash))
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     repo_key = make_repo_key('shared', '1.0.0', PackageType.WRAP)
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
@@ -1102,7 +1117,9 @@ def test_lock_two_repos_same_package_origin_reflects_winner(tmp_path: Path, monk
         'repo_b': {key_low: entry_low},
     }
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     config = MagicMock()
     config.repositories = {'repo_a': repo_a, 'repo_b': repo_b}
@@ -1151,7 +1168,9 @@ def test_lock_wrap_hash_integrity_preserved_with_origin(tmp_path: Path, monkeypa
     entry = RepoPackageEntry('shared', '1.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
 
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     args = argparse.Namespace(offline=False)
     cmd = Lock(args, context)

--- a/test/subcommand/test_remove.py
+++ b/test/subcommand/test_remove.py
@@ -6,7 +6,6 @@
 import argparse
 import hashlib
 import os
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -302,7 +301,7 @@ def test_remove_workflow_promoted_transitive_stays_quiet_when_still_needed(
             return _DummyResponse(re2_content)
         return _DummyResponse(b'')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', _urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', _urlopen)
 
     grpc_mapping = {
         'grpc': Candidate('grpc', '1.59.1', 'repo1'),

--- a/test/subcommand/test_repository_selection.py
+++ b/test/subcommand/test_repository_selection.py
@@ -3,8 +3,6 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from collider.Context import Context
 from collider.repository.implementation.Filesystem import Filesystem
 from collider.repository.implementation.RepositoryInterface import RepositoryInterface
@@ -84,8 +82,6 @@ def test_resolve_repositories_missing_returns_none(caplog) -> None:
 
 def test_resolve_filesystem_repository_found(tmp_path) -> None:
     """Test resolve_filesystem_repository returns repo and EX_OK when found and Filesystem."""
-    from pathlib import Path
-
     repo = Filesystem(tmp_path / 'repo', publish_url='file:///tmp/repo')
     (tmp_path / 'repo').mkdir(parents=True, exist_ok=True)
     config = MagicMock()

--- a/test/subcommand/test_search.py
+++ b/test/subcommand/test_search.py
@@ -3,7 +3,6 @@
 
 import argparse
 import os
-import re
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/test/subcommand/test_transitive.py
+++ b/test/subcommand/test_transitive.py
@@ -6,7 +6,6 @@
 import argparse
 import hashlib
 import os
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -128,7 +127,7 @@ def test_transitive_add_resolves_transitive_deps(tmp_path: Path, monkeypatch) ->
             return _DummyResponse(abseil_content)
         return _DummyResponse(b'')
 
-    monkeypatch.setattr(urllib.request, 'urlopen', fake_urlopen)
+    monkeypatch.setattr('collider.utils.network.safe_urlopen', fake_urlopen)
 
     args = argparse.Namespace(
         package='grpc',
@@ -186,8 +185,7 @@ def test_add_creates_colliderfile_when_missing(tmp_path: Path, monkeypatch) -> N
     context = _make_context(tmp_path, {'repo1': repo})
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -272,7 +270,7 @@ def test_transitive_rejects_unsafe_package_name(tmp_path: Path, monkeypatch) -> 
     context = _make_context(tmp_path, {'repo1': repo})
 
     monkeypatch.setattr(
-        urllib.request, 'urlopen', lambda url, **kwargs: _DummyResponse(grpc_content)
+        'collider.utils.network.safe_urlopen', lambda url, **kwargs: _DummyResponse(grpc_content)
     )
 
     resolved_mapping = {
@@ -345,8 +343,7 @@ def test_transitive_add_skips_system_deps(
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(zlib_content),
     )
 
@@ -411,8 +408,7 @@ def test_transitive_add_with_exclude_flag(tmp_path: Path, monkeypatch) -> None:
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -479,8 +475,7 @@ def test_transitive_add_persists_include_exclude_in_colliderfile(
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(zlib_content),
     )
 
@@ -549,8 +544,7 @@ def test_transitive_add_fails_on_transitive_install_failure(tmp_path: Path, monk
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -612,8 +606,7 @@ def test_transitive_add_forwards_version_spec(tmp_path: Path, monkeypatch) -> No
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(zlib_content),
     )
 
@@ -681,8 +674,7 @@ def test_transitive_add_rolls_back_on_transitive_failure(tmp_path: Path, monkeyp
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -925,8 +917,7 @@ def test_add_force_reinstalls(tmp_path: Path, monkeypatch) -> None:
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -992,8 +983,7 @@ def test_add_not_installed_proceeds_normally(tmp_path: Path, monkeypatch) -> Non
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(zlib_content),
     )
 
@@ -1064,8 +1054,7 @@ def test_add_force_removes_subproject_directory(tmp_path: Path, monkeypatch) -> 
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -1131,8 +1120,7 @@ def test_add_force_when_not_installed(tmp_path: Path, monkeypatch) -> None:
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(zlib_content),
     )
 
@@ -1205,8 +1193,7 @@ def test_add_force_updates_colliderfile(tmp_path: Path, monkeypatch) -> None:
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -1274,8 +1261,7 @@ def test_add_persists_include_conditional_flag(tmp_path: Path, monkeypatch) -> N
     resolved_mapping = {'grpc': Candidate('grpc', '1.59.1', 'repo1')}
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -1341,8 +1327,7 @@ def test_add_persists_exclude_optional_flag(tmp_path: Path, monkeypatch) -> None
     resolved_mapping = {'grpc': Candidate('grpc', '1.59.1', 'repo1')}
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(grpc_content),
     )
 
@@ -1500,7 +1485,9 @@ def test_add_skips_invalid_versions_when_selecting_newest(tmp_path: Path, monkey
 
     bad_key = make_repo_key('demo', 'not-a-version', PackageType.WRAP)
     good_key = make_repo_key('demo', '2.0.0', PackageType.WRAP)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **kwargs: _DummyResponse(content)
+    )
 
     cwd = os.getcwd()
     try:
@@ -1624,7 +1611,9 @@ def test_add_fails_when_subproject_directory_exists(tmp_path: Path, monkeypatch)
 
     demo_key = make_repo_key('demo', '1.0.0', PackageType.WRAP)
     demo_entry = RepoPackageEntry('demo', '1.0.0', PackageType.WRAP)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **kwargs: _DummyResponse(content)
+    )
 
     cwd = os.getcwd()
     try:
@@ -1668,8 +1657,7 @@ def test_add_partial_transitive_failure_leaves_installed_transitives_in_place(
     }
 
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **kwargs: _DummyResponse(
             root_content if 'grpc' in url else ok_content if 'abseil' in url else b''
         ),

--- a/test/subcommand/test_upgrade.py
+++ b/test/subcommand/test_upgrade.py
@@ -7,7 +7,6 @@ import argparse
 import hashlib
 import logging
 import os
-import urllib.request
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -95,7 +94,9 @@ def test_upgrade_one_package_replaces_existing_wrap(
     repo_key = make_repo_key('shared', '2.0.0', PackageType.WRAP)
     entry = RepoPackageEntry('shared', '2.0.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     lockfile = Lockfile(
         dependencies={
@@ -173,8 +174,7 @@ def test_upgrade_all_packages_uses_declared_constraints(tmp_path: Path, monkeypa
 
     payloads = iter([alpha_content, beta_content])
     monkeypatch.setattr(
-        urllib.request,
-        'urlopen',
+        'collider.utils.network.safe_urlopen',
         lambda url, **_kwargs: _DummyResponse(next(payloads)),
     )
 
@@ -211,7 +211,9 @@ def test_upgrade_with_version_updates_constraint(tmp_path: Path, monkeypatch) ->
     repo_key = make_repo_key('shared', '1.5.0', PackageType.WRAP)
     entry = RepoPackageEntry('shared', '1.5.0', PackageType.WRAP)
     all_matches = {'repo1': {repo_key: entry}}
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     cmd = Upgrade(
         argparse.Namespace(package='shared', version=SpecifierSet('<2.0.0'), offline=False),
@@ -302,7 +304,9 @@ def test_upgrade_does_not_warn_when_lockfile_already_matches(
         }
     )
     lockfile.save(tmp_path / Lockfile.get_filename())
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     cmd = Upgrade(argparse.Namespace(package='shared', version=None, offline=False), context)
 
@@ -337,7 +341,9 @@ def test_upgrade_offline_uses_cached_wrap(tmp_path: Path, monkeypatch) -> None:
 
     repo_key = make_repo_key('shared', '2.0.0', PackageType.WRAP)
     entry = RepoPackageEntry('shared', '2.0.0', PackageType.WRAP)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
 
     cmd = Upgrade(argparse.Namespace(package='shared', version=None, offline=True), context)
 
@@ -396,7 +402,9 @@ def test_upgrade_skips_invalid_versions(tmp_path: Path, monkeypatch) -> None:
 
     bad_key = make_repo_key('shared', 'bad-version', PackageType.WRAP)
     good_key = make_repo_key('shared', '2.0.0', PackageType.WRAP)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
     cmd = Upgrade(argparse.Namespace(package='shared', version=None, offline=False), context)
 
     cwd = os.getcwd()
@@ -477,7 +485,9 @@ def test_upgrade_fails_when_installing_downloaded_package_fails(
 
     repo_key = make_repo_key('shared', '2.0.0', PackageType.WRAP)
     entry = RepoPackageEntry('shared', '2.0.0', PackageType.WRAP)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
     cmd = Upgrade(argparse.Namespace(package='shared', version=None, offline=False), context)
 
     cwd = os.getcwd()
@@ -562,7 +572,9 @@ def test_upgrade_ignores_corrupt_lockfile_warning_check(
 
     repo_key = make_repo_key('shared', '2.0.0', PackageType.WRAP)
     entry = RepoPackageEntry('shared', '2.0.0', PackageType.WRAP)
-    monkeypatch.setattr(urllib.request, 'urlopen', lambda url, **_kwargs: _DummyResponse(content))
+    monkeypatch.setattr(
+        'collider.utils.network.safe_urlopen', lambda url, **_kwargs: _DummyResponse(content)
+    )
     cmd = Upgrade(argparse.Namespace(package='shared', version=None, offline=False), context)
 
     cwd = os.getcwd()

--- a/test/utils/test_network.py
+++ b/test/utils/test_network.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 MOG Robotics OÜ.
 
 import logging
+import socket
 import threading
 import urllib.parse
 import urllib.request
@@ -11,8 +12,10 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
+from collider.utils import network
 from collider.utils.network import (
     _AuthStrippingRedirectHandler,
+    assert_fetchable_url,
     may_send_push_token,
     safe_urlopen,
 )
@@ -125,6 +128,83 @@ def test_safe_urlopen_keeps_token_on_same_origin_redirect():
     finally:
         server.shutdown()
         thread.join()
+
+
+def test_assert_fetchable_url_rejects_non_http_scheme():
+    with pytest.raises(ValueError, match='scheme'):
+        assert_fetchable_url('ftp://example.com/foo.tar.xz')
+
+
+@pytest.mark.parametrize('address', ['127.0.0.1', '169.254.169.254', '0.0.0.0', '::1'])
+def test_assert_fetchable_url_rejects_blocked_host(monkeypatch, address: str):
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: [address])
+
+    with pytest.raises(ValueError, match='blocked'):
+        assert_fetchable_url('https://archives.example.com/foo.tar.xz')
+
+
+@pytest.mark.parametrize('address', ['93.184.216.34', '192.168.1.10', '10.0.0.5'])
+def test_assert_fetchable_url_allows_public_and_private_hosts(monkeypatch, address: str):
+    """Private LAN addresses stay allowed because self-hosted repositories are supported."""
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: [address])
+
+    assert_fetchable_url('https://archives.example.com/foo.tar.xz')
+
+
+def test_assert_fetchable_url_rejects_unresolvable_host(monkeypatch):
+    def _fail(_host):
+        raise socket.gaierror('no such host')
+
+    monkeypatch.setattr(network, '_resolve_host_addresses', _fail)
+
+    with pytest.raises(ValueError, match='resolve'):
+        assert_fetchable_url('https://archives.example.com/foo.tar.xz')
+
+
+def test_redirect_rejects_non_http_target():
+    handler = _AuthStrippingRedirectHandler()
+    request = _make_request('https://example.com/a')
+
+    with pytest.raises(ValueError, match='non-http'):
+        handler.redirect_request(request, None, 302, 'Found', {}, 'ftp://example.com/b')
+
+
+def test_redirect_rejects_blocked_host_when_checking(monkeypatch):
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: ['169.254.169.254'])
+    handler = _AuthStrippingRedirectHandler(check_redirect_hosts=True)
+    request = _make_request('https://example.com/a')
+
+    with pytest.raises(ValueError, match='blocked'):
+        handler.redirect_request(request, None, 302, 'Found', {}, 'https://metadata.internal/x')
+
+
+def test_redirect_rechecks_same_host_when_checking(monkeypatch):
+    """A same-host redirect re-resolves: attacker DNS can rebind the name between hops."""
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: ['127.0.0.1'])
+    handler = _AuthStrippingRedirectHandler(check_redirect_hosts=True)
+    request = _make_request('https://evil.example.com/a')
+
+    with pytest.raises(ValueError, match='blocked'):
+        handler.redirect_request(request, None, 302, 'Found', {}, 'https://evil.example.com/b')
+
+
+def test_redirect_allows_blocked_host_without_checking(monkeypatch):
+    """Trusted callers (user-configured repos) may legitimately redirect to loopback."""
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: ['127.0.0.1'])
+    handler = _AuthStrippingRedirectHandler()
+    request = _make_request('https://repo.example.com/a')
+
+    new_req = handler.redirect_request(request, None, 302, 'Found', {}, 'https://repo.local/b')
+
+    assert new_req is not None
+
+
+def test_assert_fetchable_url_rejects_ipv4_mapped_ipv6(monkeypatch):
+    """An IPv4-mapped IPv6 address must be judged by its embedded IPv4 address."""
+    monkeypatch.setattr(network, '_resolve_host_addresses', lambda _host: ['::ffff:127.0.0.1'])
+
+    with pytest.raises(ValueError, match='blocked'):
+        assert_fetchable_url('https://archives.example.com/foo.tar.xz')
 
 
 def test_may_send_push_token_allows_https():

--- a/test/utils/test_utils.py
+++ b/test/utils/test_utils.py
@@ -68,7 +68,7 @@ def test_discover_plugins_import_error(caplog) -> None:
         # Mock import_module to raise ImportError
         with patch('importlib.import_module', side_effect=ImportError('Mocked import error')):
             with pytest.raises(ImportError, match='Mocked import error'):
-                plugins = core.discover_plugins(mock_package)
+                core.discover_plugins(mock_package)
 
 
 def test_run_command_success() -> None:


### PR DESCRIPTION
## Summary

Addresses the Bandit B101 (assert in production code) findings from the Codacy report.

- `pkg add`: when every matching package carries an unparsable version, `_find_newest_package` now returns `None` so the command reports no match and exits with `EX_UNAVAILABLE`. Previously this path crashed with an `AssertionError` traceback. Regression test added.
- Drop five asserts that neither guard runtime behavior nor narrow types for `ty`: tautological checks in `FileModelInterface` and argument type guards in `command.run` (subprocess rejects wrong types on its own, `shell=False` throughout).

The remaining asserts in the package are load-bearing for `ty` type narrowing and are kept.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.
