### PR TITLE
ci: exempt dependabot from the PR checklist

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   checklist:
-    if: ${{ github.actor != 'nektos/act' }}
+    # Dependabot PRs are machine-generated and never fill the template, so the checklist
+    # does not apply to them.
+    if: ${{ github.actor != 'nektos/act' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify checklist and AI disclosure


### PR DESCRIPTION
## Summary

Dependabot PRs are machine-generated and never fill the PR template, so the checklist job fails on every dependency-update PR. This skips the checklist job when the PR author is dependabot[bot]. A skipped job satisfies required status checks, so dependabot PRs are mergeable again. All human-authored PRs keep the full checklist and AI disclosure requirements.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (please describe): CI configuration

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.