### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "collider-wraps"
-version = "1.5.0"
+version = "1.5.1"
 description = "Modern package management for Meson's wrap ecosystem."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "collider-wraps"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

Patch version bump 1.5.0 -> 1.5.1 in `pyproject.toml` and `uv.lock`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Other (please describe): version bump / release chore

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/MaxandreOgeret/collider/blob/main/CONTRIBUTING.md).
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Tests pass (`uv run pytest`).
- [x] Format, lint, type, and static checks pass (`uv run ruff format --check .`, `uv run ruff check .`, `uv run ty check collider`, `uv run pylint --rcfile=pyproject.toml ./collider`).

## AI disclosure (Tick all that apply)

- [ ] AI tools were used for part or all of this change.
  - [ ] A **human** (not an AI agent) has reviewed every line, understands the change, and takes full responsibility for what is submitted.
